### PR TITLE
Adding source secret option for jenkins-s2i

### DIFF
--- a/templates/jenkins-s2i-build/template.json
+++ b/templates/jenkins-s2i-build/template.json
@@ -108,7 +108,7 @@
             "name": "PIPELINE_SOURCE_SECRET",
             "displayName": "Secret for git repository",
             "description": "The name of the OCP secret that has credentials for the pipeline git repository",
-            "value": "git-pipeline-secret"
+            "value": ""
         },
         {
             "name": "SOURCE_REPOSITORY_URL",

--- a/templates/jenkins-s2i-build/template.json
+++ b/templates/jenkins-s2i-build/template.json
@@ -35,6 +35,9 @@
                     "git": {
                         "uri": "${SOURCE_REPOSITORY_URL}",
                         "ref": "${SOURCE_REPOSITORY_REF}"
+                    },
+                    "sourceSecret": {
+                        "name": "${PIPELINE_SOURCE_SECRET}"
                     }
                 },
                 "strategy": {
@@ -100,6 +103,12 @@
             "description": "A secret string used to configure the GitHub webhook.",
             "generate": "expression",
             "from": "[a-zA-Z0-9]{40}"
+        },
+        {
+            "name": "PIPELINE_SOURCE_SECRET",
+            "displayName": "Secret for git repository",
+            "description": "The name of the OCP secret that has credentials for the pipeline git repository",
+            "value": "git-pipeline-secret"
         },
         {
             "name": "SOURCE_REPOSITORY_URL",


### PR DESCRIPTION
Solving issue #21 
Adds the option to use a secret with an ssh-key for a private repo.

To test this, it should be verified that it works with both a public (no key) and a private repo (with key).