### PR TITLE
Add gitlab with ldap and a template to allow a project (gitlab) to ru…

### DIFF
--- a/templates/gitlab/template-ldap.json
+++ b/templates/gitlab/template-ldap.json
@@ -1,0 +1,821 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "gitlab-ce",
+    "annotations": {
+      "iconClass": "fa fa-git",
+      "description": "GitLab. Collaboration and source control management: code, test, and deploy together! \n\n GitLab requries that the serviceaccount for the main GitLab app be added to the anyuid security context. The service account name is: <application name>-user",
+      "tags": "instant-app,gitlab,VCS"
+    }
+  },
+  "labels": {
+    "createdBy": "gitlab-ce-template"
+  },
+  "parameters": [
+    {
+      "description": "A label that will be seen by the user at login",
+      "displayName": "LDAP label.",
+      "name": "LDAP_LABEL",
+      "value": "RH Labs"
+    },
+    {
+      "description": "The host URL",
+      "displayName": "LDAP HOST",
+      "name": "LDAP_HOST",
+      "required": true
+    },    
+    {
+      "description": "The LDAP port",
+      "displayName": "LDAP port",
+      "name": "LDAP_PORT",
+      "value": "636"
+    },
+    {
+      "description": "The LDAP bind dn",
+      "displayName": "LDAP BIND_DN",
+      "name": "LDAP_BIND_DN",
+      "required": true
+    },
+    {
+      "description": "The LDAP password",
+      "displayName": "LDAP password",
+      "name": "LDAP_PASSWORD",
+      "required": true
+    },
+    {
+      "description": "Verify LDAP certificate",
+      "displayName": "Verify LDAP cert",
+      "name": "LDAP_VERIFY_CERTIFICATE",
+      "value": "false"
+    },
+    {
+      "description": "The type of encryption (ex. simple_tls)",
+      "displayName": "LDAP encryption type",
+      "name": "LDAP_ENCRYPTION",
+      "value": "simple_tls"
+    },
+    {
+      "description": "LDAP Base",
+      "displayName": "LDAP Base",
+      "name": "LDAP_BASE",
+      "required": false
+    },
+    {
+      "description": "LDAP User filter",
+      "displayName": "LDAP user filter",
+      "name": "LDAP_USER_FILTER",
+      "value": ""
+    },
+    {
+      "description": "The name for the application. The service will be named like the application.",
+      "displayName": "Application name.",
+      "name": "APPLICATION_NAME",
+      "value": "gitlab-ce"
+    },
+    {
+      "description": "Hostname for service routes. Set this in order to have the GitLab display the correct clone urls.",
+      "displayName": "Gitlab instance hostname",
+      "name": "APPLICATION_HOSTNAME",
+      "required": true
+    },
+    {
+      "name": "GITLAB_ROOT_PASSWORD",
+      "displayName": "GitLab Root User Password",
+      "description": "Password for the GitLab 'root' user. Must be at least 8 characters long. Leave blank if you would rather configure the password using the website during first use."
+    },
+    {
+      "name": "POSTGRESQL_USER",
+      "displayName": "PostgreSQL User",
+      "description": "Username for PostgreSQL user that will be used for accessing the database.",
+      "generate": "expression",
+      "from": "user[A-Z0-9]{3}",
+      "required": true
+    },
+    {
+      "name": "POSTGRESQL_PASSWORD",
+      "displayName": "PostgreSQL Password",
+      "description": "Password for the PostgreSQL user.",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{16}",
+      "required": true
+    },
+    {
+      "name": "POSTGRESQL_ADMIN_PASSWORD",
+      "displayName": "PostgreSQL Admin User Password",
+      "description": "Password for the PostgreSQL Admin user.",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{16}",
+      "required": true
+    },
+    {
+      "name": "POSTGRESQL_DATABASE",
+      "displayName": "PostgreSQL Database Name",
+      "description": "Name of the PostgreSQL database accessed.",
+      "value": "gitlabhq_production",
+      "required": true
+    },
+    {
+      "name": "UNICORN_WORKERS",
+      "displayName": "Number of Unicorn Workers",
+      "description": "Number of Unicorn Workers to use per instance. Must be at least 2.",
+      "value": "2",
+      "required": true
+    },
+    {
+      "description": "Volume size for /etc",
+      "displayName": "/etc/gitlab volume size",
+      "name": "ETC_VOL_SIZE",
+      "value": "100Mi"
+    },
+    {
+      "description": "Volume size for GitLab data",
+      "displayName": "GitLab data volume size",
+      "name": "GITLAB_DATA_VOL_SIZE",
+      "value": "5Gi"
+    },
+    {
+      "description": "Volume size for postgresql data",
+      "displayName": "postgresql volume size",
+      "name": "POSTGRESQL_VOL_SIZE",
+      "value": "2Gi"
+    },
+    {
+      "description": "Volume size for redis data",
+      "displayName": "redis volume size",
+      "name": "REDIS_VOL_SIZE",
+      "value": "512Mi"
+    }
+  ],
+  "objects": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}",
+        "labels": {
+          "app": "${APPLICATION_NAME}"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "gitlab-10.0.4",
+            "from": {
+              "kind": "DockerImage",
+              "name": "gitlab/gitlab-ce:10.0.4-ce.0"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}-redis",
+        "labels": {
+          "app": "${APPLICATION_NAME}"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "3.2.3",
+            "from": {
+              "kind": "DockerImage",
+              "name": "redis:3.2.3-alpine"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": "gitlab-secrets"
+      },
+      "stringData": {
+        "ldap-password": "${LDAP_PASSWORD}",
+        "gitlab-root-password": "${GITLAB_ROOT_PASSWORD}",
+        "postgresql-password": "${POSTGRESQL_PASSWORD}",
+        "postgresql-admin-password": "${POSTGRESQL_ADMIN_PASSWORD}"
+      }
+    },
+    {
+      "kind": "ServiceAccount",
+        "apiVersion": "v1",
+        "metadata": {
+          "name": "${APPLICATION_NAME}-user"
+        }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}",
+        "labels": {
+          "app": "${APPLICATION_NAME}"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "recreateParams": {},
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "gitlab-ce"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "${APPLICATION_NAME}:gitlab-10.0.4"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "app": "${APPLICATION_NAME}",
+          "deploymentconfig": "${APPLICATION_NAME}"
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "app": "${APPLICATION_NAME}",
+              "deploymentconfig": "${APPLICATION_NAME}"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "gitlab-ce-volume-1",
+                "persistentVolumeClaim": {
+                  "claimName": "${APPLICATION_NAME}-etc"
+                }
+              },
+              {
+                "name": "gitlab-ce-volume-2",
+                "persistentVolumeClaim": {
+                  "claimName": "${APPLICATION_NAME}-data"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "gitlab-ce",
+                "image": "gitlab-ce",
+                "ports": [
+                  {
+                    "containerPort": 22,
+                    "protocol": "TCP"
+                  },
+                  {
+                    "containerPort": 80,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "GITLAB_OMNIBUS_CONFIG",
+                    "value": "hostname='${APPLICATION_HOSTNAME}'; external_url \"http://#{hostname}/\" unless hostname.to_s == ''; root_pass=ENV[\"{GITLAB_ROOT_PASSWORD\"]; gitlab_rails['initial_root_password']=root_pass unless root_pass.to_s == ''; postgresql['enable']=false; gitlab_rails['db_host'] = '${APPLICATION_NAME}-postgresql'; gitlab_rails['db_password']=ENV[\"POSTGRESQL_PASSWORD\"]; gitlab_rails['db_username']='${POSTGRESQL_USER}'; gitlab_rails['db_database']='${POSTGRESQL_DATABASE}'; redis['enable'] = false; gitlab_rails['redis_host']='${APPLICATION_NAME}-redis'; unicorn['worker_processes'] = ${UNICORN_WORKERS}; manage_accounts['enable'] = true; manage_storage_directories['manage_etc'] = false; gitlab_shell['auth_file'] = '/gitlab-data/ssh/authorized_keys'; git_data_dirs({ 'default' => { 'path' => '/gitlab-data/git-data' } }); gitlab_rails['shared_path'] = '/gitlab-data/shared'; gitlab_rails['uploads_directory'] = '/gitlab-data/uploads'; gitlab_ci['builds_directory'] = '/gitlab-data/builds'; prometheus_monitoring['enable'] = false; gitlab_rails['ldap_enabled'] = true; gitlab_rails['ldap_servers'] = { 'main' => { 'label' => ENV[\"LDAP_LABEL\"], 'host' =>  ENV[\"LDAP_HOST\"], 'port' => ENV[\"LDAP_PORT\"], 'uid' => 'uid', 'bind_dn' => ENV[\"LDAP_BIND_DN\"], 'password' => ENV[\"LDAP_PASSWORD\"], 'encryption' => '${LDAP_ENCRYPTION}', 'verify_certificates' => ${LDAP_VERIFY_CERTIFICATE}, 'allow_username_or_email_login' => true, 'block_auto_created_users' => false, 'active_directory' => false, 'base' => ENV[\"LDAP_BASE\"], 'user_filter' => ENV[\"LDAP_USER_FILTER\"], 'attributes' => { 'username' => ['uid'], 'email' => ['mail'], 'name' => 'displayName' } } };"
+                  },
+                  {
+                    "name": "LDAP_LABEL",
+                    "value": "${LDAP_LABEL}"
+                  },
+                  {
+                    "name": "LDAP_HOST",
+                    "value": "${LDAP_HOST}"
+                  },
+                  {
+                    "name": "LDAP_PORT",
+                    "value": "${LDAP_PORT}"
+                  },
+                  {
+                    "name": "LDAP_BIND_DN",
+                    "value": "${LDAP_BIND_DN}"
+                  },
+                  {
+                    "name": "LDAP_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "ldap-password",
+                        "name": "gitlab-secrets"
+                      }
+                    }
+                  },
+                  {
+                    "name": "LDAP_BASE",
+                    "value": "${LDAP_BASE}"
+                  },
+                  {
+                    "name": "LDAP_USER_FILTER",
+                    "value": "${LDAP_USER_FILTER}"
+                  },
+                  {
+                    "name": "GITLAB_ROOT_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "gitlab-root-password",
+                        "name": "gitlab-secrets"
+                      }
+                    }
+                  },
+                  {
+                    "name": "POSTGRESQL_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "postgresql-password",
+                        "name": "gitlab-secrets"
+                      }
+                    }
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "2Gi"
+                  },
+                  "requests": {
+                    "cpu": "500m",
+                    "memory": "1Gi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "name": "gitlab-ce-volume-1",
+                    "mountPath": "/etc/gitlab"
+                  },
+                  {
+                    "name": "gitlab-ce-volume-2",
+                    "mountPath": "/gitlab-data"
+                  }
+                ],
+                "livenessProbe": {
+                  "httpGet": {
+                    "path": "/help",
+                    "port": 80,
+                    "scheme": "HTTP"
+                  },
+                  "initialDelaySeconds": 120,
+                  "timeoutSeconds": 1,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
+                },
+                "readinessProbe": {
+                  "httpGet": {
+                    "path": "/help",
+                    "port": 80,
+                    "scheme": "HTTP"
+                  },
+                  "initialDelaySeconds": 20,
+                  "timeoutSeconds": 1,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
+                },
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "restartPolicy": "Always",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst",
+            "serviceAccount": "${APPLICATION_NAME}-user"
+          }
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}-redis",
+        "labels": {
+          "app": "${APPLICATION_NAME}"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "recreateParams": {},
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "gitlab-ce-redis"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "${APPLICATION_NAME}-redis:3.2.3"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "app": "${APPLICATION_NAME}",
+          "deploymentconfig": "${APPLICATION_NAME}-redis"
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "app": "${APPLICATION_NAME}",
+              "deploymentconfig": "${APPLICATION_NAME}-redis"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "gitlab-ce-volume-4",
+                "persistentVolumeClaim": {
+                  "claimName": "${APPLICATION_NAME}-redis-data"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "gitlab-ce-redis",
+                "image": "gitlab-ce-redis",
+                "command": ["/bin/sh", "-ec"],
+                "args": ["exec redis-server"],
+                "ports": [
+                  {
+                    "containerPort": 6379,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "512Mi"
+                  },
+                  "requests": {
+                    "cpu": "100m",
+                    "memory": "300Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "name": "gitlab-ce-volume-4",
+                    "mountPath": "/data"
+                  }
+                ],
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "restartPolicy": "Always",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst"
+          }
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}-postgresql",
+        "labels": {
+          "app": "${APPLICATION_NAME}"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "recreateParams": {
+            "post": {
+              "failurePolicy": "Abort",
+              "execNewPod": {
+                "containerName": "gitlab-ce-postgresql",
+                "command": [
+                  "/usr/bin/scl",
+                  "enable",
+                  "rh-postgresql94",
+                  "export PGPASSWORD='${POSTGRESQL_ADMIN_PASSWORD}'; psql -h '${APPLICATION_NAME}-postgresql' -U postgres -d ${POSTGRESQL_DATABASE} -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'"
+                ],
+                "env": [
+                  { "name": "HOME", "value": "/var/lib/pgsql" },
+                  { "name": "PGDATA", "value": "/var/lib/pgsql/data/userdata" },
+                  { "name": "CONTAINER_SCRIPTS_PATH", "value": "/usr/share/container-scripts/postgresql" }
+                ]
+              }
+            }
+          },
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "gitlab-ce-postgresql"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "postgresql:9.4",
+                "namespace": "openshift"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "app": "${APPLICATION_NAME}",
+          "deploymentconfig": "${APPLICATION_NAME}-postgresql"
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "app": "${APPLICATION_NAME}",
+              "deploymentconfig": "${APPLICATION_NAME}-postgresql"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "gitlab-ce-volume-3",
+                "persistentVolumeClaim": {
+                  "claimName": "${APPLICATION_NAME}-postgresql"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "gitlab-ce-postgresql",
+                "image": "gitlab-ce-postgresql",
+                "ports": [
+                  {
+                    "containerPort": 5432,
+                    "protocol": "TCP"
+                  }
+                ],
+                "readinessProbe": {
+                  "timeoutSeconds": 1,
+                  "initialDelaySeconds": 5,
+                  "exec": {
+                    "command": [ "/bin/sh", "-i", "-c", "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"]
+                  }
+                },
+                "livenessProbe": {
+                  "timeoutSeconds": 1,
+                  "initialDelaySeconds": 30,
+                  "tcpSocket": {
+                    "port": 5432
+                  }
+                },
+                "env": [
+                  {
+                    "name": "POSTGRESQL_USER",
+                    "value": "${POSTGRESQL_USER}"
+                  },
+                  {
+                    "name": "POSTGRESQL_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "postgresql-password",
+                        "name": "gitlab-secrets"
+                      }
+                    }
+                  },
+                  {
+                    "name": "POSTGRESQL_DATABASE",
+                    "value": "${POSTGRESQL_DATABASE}"
+                  },
+                  {
+                    "name": "POSTGRESQL_ADMIN_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "postgresql-admin-password",
+                        "name": "gitlab-secrets"
+                      }
+                    }
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "512Mi"
+                  },
+                  "requests": {
+                    "cpu": "300m",
+                    "memory": "300Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "name": "gitlab-ce-volume-3",
+                    "mountPath": "/var/lib/pgsql/data"
+                  }
+                ],
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "restartPolicy": "Always",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst"
+          }
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}",
+        "labels": {
+          "app": "${APPLICATION_NAME}"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "22-ssh",
+            "protocol": "TCP",
+            "port": 22,
+            "targetPort": 22
+          },
+          {
+            "name": "80-http",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 80
+          }
+        ],
+        "selector": {
+          "app": "${APPLICATION_NAME}",
+          "deploymentconfig": "${APPLICATION_NAME}"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}-redis",
+        "labels": {
+          "app": "${APPLICATION_NAME}"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379-redis",
+            "protocol": "TCP",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "app": "${APPLICATION_NAME}",
+          "deploymentconfig": "${APPLICATION_NAME}-redis"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      }
+    },
+    {
+       "kind": "Service",
+       "apiVersion": "v1",
+       "metadata": {
+         "name": "${APPLICATION_NAME}-postgresql",
+         "labels": {
+           "app": "${APPLICATION_NAME}"
+         }
+       },
+       "spec": {
+         "ports": [
+           {
+             "name": "5432-postgresql",
+             "protocol": "TCP",
+             "port": 5432,
+             "targetPort": 5432
+           }
+         ],
+         "selector": {
+           "app": "${APPLICATION_NAME}",
+           "deploymentconfig": "${APPLICATION_NAME}-postgresql"
+         },
+         "type": "ClusterIP",
+         "sessionAffinity": "None"
+       }
+     },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}-redis-data"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "${REDIS_VOL_SIZE}"
+          }
+        }
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}-etc"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "${ETC_VOL_SIZE}"
+          }
+        }
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}-data"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "${GITLAB_DATA_VOL_SIZE}"
+          }
+        }
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}-postgresql"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "${POSTGRESQL_VOL_SIZE}"
+          }
+        }
+      }
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${APPLICATION_NAME}",
+        "labels": {
+          "app": "${APPLICATION_NAME}"
+        }
+      },
+      "spec": {
+        "host": "${APPLICATION_HOSTNAME}",
+        "to": {
+          "kind": "Service",
+          "name": "${APPLICATION_NAME}"
+        },
+        "port": {
+          "targetPort": "80-http"
+        }
+      }
+    }
+  ]
+}

--- a/templates/scc/template-project-run-anyuid.json
+++ b/templates/scc/template-project-run-anyuid.json
@@ -26,7 +26,7 @@
                 "type": "RunAsAny"
             }, 
             "apiVersion": "v1", 
-            "priority": 9, 
+            "priority": "${{PRIORITY_LEVEL}}", 
             "volumes": [
                 "configMap", 
                 "downwardAPI", 
@@ -66,6 +66,12 @@
             "displayName": "Namespace", 
             "description": "The NameSpace to Deploy to", 
             "name": "NAMESPACE"
+        }, 
+        {
+            "value": "8",
+            "displayName": "Priority",
+            "description": "A number to represent the priority of the defined SCC vs other SCCs. 1 is the highest priority. Null is the lowest. Ties go from the least privileged to the most privileged.",
+            "name": "PRIORITY_LEVEL"
         }
     ], 
     "metadata": {

--- a/templates/scc/template-project-run-anyuid.json
+++ b/templates/scc/template-project-run-anyuid.json
@@ -1,0 +1,75 @@
+{
+    "kind": "Template", 
+    "objects": [
+        {
+            "readOnlyRootFilesystem": false, 
+            "users": [
+                "system:serviceaccount:${NAMESPACE}:${NAME}"
+            ], 
+            "allowPrivilegedContainer": false, 
+            "allowHostPorts": false, 
+            "groups": [
+                "system:cluster-admins"
+            ], 
+            "allowHostPID": false, 
+            "allowHostDirVolumePlugin": false, 
+            "allowedCapabilities": [], 
+            "kind": "SecurityContextConstraints", 
+            "allowHostIPC": false, 
+            "runAsUser": {
+                "type": "RunAsAny"
+            }, 
+            "supplementalGroups": {
+                "type": "RunAsAny"
+            }, 
+            "fsGroup": {
+                "type": "RunAsAny"
+            }, 
+            "apiVersion": "v1", 
+            "priority": 9, 
+            "volumes": [
+                "configMap", 
+                "downwardAPI", 
+                "emptyDir", 
+                "persistentVolumeClaim", 
+                "projected", 
+                "secret"
+            ], 
+            "seLinuxContext": {
+                "type": "MustRunAs"
+            }, 
+            "defaultAddCapabilities": [], 
+            "allowHostNetwork": false, 
+            "requiredDropCapabilities": [
+                "MKNOD", 
+                "SYS_CHROOT"
+            ], 
+            "metadata": {
+                "creationTimestamp": null, 
+                "annotations": {
+                    "kubernetes.io/description": "anyuid provides all features of the restricted SCC but allows users to run with any UID and any GID."
+                }, 
+                "name": "${NAME}-anyuid"
+            }
+        }
+    ], 
+    "apiVersion": "v1", 
+    "parameters": [
+        {
+            "required": true, 
+            "displayName": "Application Name", 
+            "name": "NAME", 
+            "description": "Name of the Application"
+        }, 
+        {
+            "required": true, 
+            "displayName": "Namespace", 
+            "description": "The NameSpace to Deploy to", 
+            "name": "NAMESPACE"
+        }
+    ], 
+    "metadata": {
+        "creationTimestamp": null, 
+        "name": "${NAME}"
+    }
+}


### PR DESCRIPTION
…n as root

Create git lab with LDAP, postgres and redis - secrets for passwords used.

Scc template to be able to run as root. This will create a new scc that will have that ability for a specific namespace and user (passed as param)