### PR TITLE
Tools container update

### DIFF
--- a/docker/tool-box/Dockerfile
+++ b/docker/tool-box/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf -y update && \
     dnf -y install $PACKAGE_LIST && \
     dnf clean all && \
     curl -o /tmp/oc.tar.gz $OC_CLIENT_MIRROR && \
-    tar zxf /tmp/oc.tar.gz -C /usr/bin/ --strip-components=1 2> /dev/null && \
+    tar zxf /tmp/oc.tar.gz -C /usr/bin/  && \
     rm /tmp/oc.tar.gz && \
     mkdir -m 775 $HOME && \
     chmod 775 /etc/passwd

--- a/docker/tool-box/Dockerfile
+++ b/docker/tool-box/Dockerfile
@@ -2,18 +2,17 @@ FROM fedora:latest
 
 ENV PACKAGE_LIST git ansible tree vim
 ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.6.173.0.21/linux/oc.tar.gz
-
-RUN dnf -y update && dnf -y install $PACKAGE_LIST && dnf clean all
-
-RUN cd tmp && \
-    curl $OC_CLIENT_MIRROR -o oc.tar.gz && \
-    tar -vxzf oc.tar.gz && \
-    mv oc /usr/bin/oc && \
-    rm oc.tar.gz
-
 ENV HOME /home/tool-box
 
-RUN mkdir -m 775 $HOME && chmod 775 /etc/passwd
+RUN dnf -y update && \
+    dnf -y install $PACKAGE_LIST && \
+    dnf clean all && \
+    curl -o /tmp/oc.tar.gz $OC_CLIENT_MIRROR && \
+    tar zxf /tmp/oc.tar.gz -C /usr/bin/ --strip-components=1 2> /dev/null && \
+    rm /tmp/oc.tar.gz && \
+    mkdir -m 775 $HOME && \
+    chmod 775 /etc/passwd
+    
 WORKDIR $HOME
 
 ADD ./s2i /usr/libexec/s2i

--- a/docker/tool-box/s2i/run
+++ b/docker/tool-box/s2i/run
@@ -6,8 +6,16 @@
 USER_ID=$(id -u)
 GROUP_ID=$(id -g)
 
-if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"997" ]; then
-  echo "tool-box:x:${USER_ID}:${GROUP_ID}:Tool Box User:${HOME}:/sbin/nologin" >> /etc/passwd
+# Check if user already exists
+ADD_USER=$(grep $USER_ID /etc/passwd | wc -l)
+
+if [ $ADD_USER -eq 0 ];then
+  echo "User $USER_ID does not exists. Adding the user to /etc/passwd..."
+  if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"997" ]; then
+    echo "tool-box:x:${USER_ID}:${GROUP_ID}:Tool Box User:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+else
+  echo "User $USER_ID already exists"
 fi
 
-tail -f /dev/null
+sleep infinity


### PR DESCRIPTION
@sherl0cks just a few updates on the Dockerfile to get fewer layers and another update in the entry point script to prevent the same user to be created many times (even that could not happen in an OCP environment, but just in case someone decides to use it with "standalone" docker).

Regarding the command to maintain the container alive, as @InfoSec812 said, OCP doesn't allocate a pseudo-tty, event that, just moved to 'sleep infinity' as this is initially a better approach to do that.