### PR TITLE
Reordering ImageStreams before BuildConfigs

### DIFF
--- a/templates/gogs/gogs-persistent-template.yaml
+++ b/templates/gogs/gogs-persistent-template.yaml
@@ -6,6 +6,23 @@ metadata:
     tags: instant-app,gogs,go,golang
   name: gogs
 objects:
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    labels:
+      app: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    tags:
+    - name: "${GOGS_VERSION}"
+      from:
+        kind: DockerImage
+        name: docker.io/makentenza/gogs:${GOGS_VERSION}
+      importPolicy: {}
+      annotations:
+        description: The Gogs git server docker image
+        tags: gogs,go,golang
+        version: "${GOGS_VERSION}"
 - kind: ServiceAccount
   apiVersion: v1
   metadata:
@@ -226,23 +243,6 @@ objects:
           kind: ImageStreamTag
           name: ${APPLICATION_NAME}:${GOGS_VERSION}
       type: ImageChange
-- kind: ImageStream
-  apiVersion: v1
-  metadata:
-    labels:
-      app: ${APPLICATION_NAME}
-    name: ${APPLICATION_NAME}
-  spec:
-    tags:
-    - name: "${GOGS_VERSION}"
-      from:
-        kind: DockerImage
-        name: docker.io/makentenza/gogs:${GOGS_VERSION}
-      importPolicy: {}
-      annotations:
-        description: The Gogs git server docker image
-        tags: gogs,go,golang
-        version: "${GOGS_VERSION}"
 - kind: PersistentVolumeClaim
   apiVersion: v1
   metadata:

--- a/templates/jenkins-s2i-build/template-with-secret.json
+++ b/templates/jenkins-s2i-build/template-with-secret.json
@@ -12,6 +12,37 @@
     },
     "objects": [
         {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${NAME}",
+                "annotations": {
+                    "description": "Keeps track of changes in the application image"
+                }
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "jenkins-2-rhel7"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/imported-from": "registry.access.redhat.com/openshift3/jenkins-2-rhel7"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7"
+                        }
+                    }
+                ]
+            }
+        },
+        {
             "kind": "BuildConfig",
             "apiVersion": "v1",
             "metadata": {
@@ -55,37 +86,6 @@
                         "name": "${NAME}:latest"
                     }
                 }
-            }
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${NAME}",
-                "annotations": {
-                    "description": "Keeps track of changes in the application image"
-                }
-            }
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jenkins-2-rhel7"
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "latest",
-                        "annotations": {
-                            "openshift.io/imported-from": "registry.access.redhat.com/openshift3/jenkins-2-rhel7"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7"
-                        }
-                    }
-                ]
             }
         }
     ],

--- a/templates/jenkins-s2i-build/template.json
+++ b/templates/jenkins-s2i-build/template.json
@@ -12,6 +12,37 @@
     },
     "objects": [
         {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${NAME}",
+                "annotations": {
+                    "description": "Keeps track of changes in the application image"
+                }
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "jenkins-2-rhel7"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/imported-from": "registry.access.redhat.com/openshift3/jenkins-2-rhel7"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7"
+                        }
+                    }
+                ]
+            }
+        },
+        {
             "kind": "BuildConfig",
             "apiVersion": "v1",
             "metadata": {
@@ -52,37 +83,6 @@
                         "name": "${NAME}:latest"
                     }
                 }
-            }
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${NAME}",
-                "annotations": {
-                    "description": "Keeps track of changes in the application image"
-                }
-            }
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jenkins-2-rhel7"
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "latest",
-                        "annotations": {
-                            "openshift.io/imported-from": "registry.access.redhat.com/openshift3/jenkins-2-rhel7"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7"
-                        }
-                    }
-                ]
             }
         }
     ],

--- a/templates/jenkins-slave-pod/template-with-secret.json
+++ b/templates/jenkins-slave-pod/template-with-secret.json
@@ -11,6 +11,32 @@
     "objects": [
         {
             "apiVersion": "v1",
+            "kind": "ImageStream",
+            "metadata": {
+                "labels": {
+                    "build": "${NAME}"
+                },
+                "name": "jenkins-slave-base-rhel7"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "openshift/jenkins-slave-base-rhel7:latest"
+                        },
+                        "generation": 2,
+                        "importPolicy": {},
+                        "name": "latest",
+                        "referencePolicy": {
+                            "type": "Source"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
             "kind": "BuildConfig",
             "metadata": {
                 "labels": {
@@ -74,32 +100,6 @@
                     "role": "jenkins-slave"
                 },
                 "name": "${NAME}"
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "ImageStream",
-            "metadata": {
-                "labels": {
-                    "build": "${NAME}"
-                },
-                "name": "jenkins-slave-base-rhel7"
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "openshift/jenkins-slave-base-rhel7:latest"
-                        },
-                        "generation": 2,
-                        "importPolicy": {},
-                        "name": "latest",
-                        "referencePolicy": {
-                            "type": "Source"
-                        }
-                    }
-                ]
             }
         }
     ],

--- a/templates/jenkins-slave-pod/template.json
+++ b/templates/jenkins-slave-pod/template.json
@@ -11,6 +11,43 @@
     "objects": [
         {
             "apiVersion": "v1",
+            "kind": "ImageStream",
+            "metadata": {
+                "labels": {
+                    "build": "${NAME}"
+                },
+                "name": "jenkins-slave-base-rhel7"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "openshift/jenkins-slave-base-rhel7:latest"
+                        },
+                        "generation": 2,
+                        "importPolicy": {},
+                        "name": "latest",
+                        "referencePolicy": {
+                            "type": "Source"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ImageStream",
+            "metadata": {
+                "labels": {
+                    "build": "${NAME}",
+                    "role": "jenkins-slave"
+                },
+                "name": "${NAME}"
+            }
+        },
+        {
+            "apiVersion": "v1",
             "kind": "BuildConfig",
             "metadata": {
                 "labels": {
@@ -58,43 +95,6 @@
                     },
                     {
                         "type": "ImageChange"
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "ImageStream",
-            "metadata": {
-                "labels": {
-                    "build": "${NAME}",
-                    "role": "jenkins-slave"
-                },
-                "name": "${NAME}"
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "ImageStream",
-            "metadata": {
-                "labels": {
-                    "build": "${NAME}"
-                },
-                "name": "jenkins-slave-base-rhel7"
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "openshift/jenkins-slave-base-rhel7:latest"
-                        },
-                        "generation": 2,
-                        "importPolicy": {},
-                        "name": "latest",
-                        "referencePolicy": {
-                            "type": "Source"
-                        }
                     }
                 ]
             }

--- a/templates/nexus/template.json
+++ b/templates/nexus/template.json
@@ -15,6 +15,34 @@
   },
   "objects": [
     {
+      "apiVersion": "v1",
+      "kind": "ImageStream",
+      "metadata": {
+        "labels": {
+          "name": "${NAME}"
+        },
+        "name": "${NAME}"
+      },
+      "spec": {
+        "tags": [
+          {
+            "annotations": {
+              "openshift.io/imported-from": "${CONTAINER_IMAGE}"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "${CONTAINER_IMAGE}"
+            },
+            "importPolicy": {},
+            "name": "latest",
+            "referencePolicy": {
+              "type": "Source"
+            }
+          }
+        ]
+      }
+    },
+    {
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
@@ -150,34 +178,6 @@
         },
         "sessionAffinity": "None",
         "type": "ClusterIP"
-      }
-    },
-    {
-      "apiVersion": "v1",
-      "kind": "ImageStream",
-      "metadata": {
-        "labels": {
-          "name": "${NAME}"
-        },
-        "name": "${NAME}"
-      },
-      "spec": {
-        "tags": [
-          {
-            "annotations": {
-              "openshift.io/imported-from": "${CONTAINER_IMAGE}"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "${CONTAINER_IMAGE}"
-            },
-            "importPolicy": {},
-            "name": "latest",
-            "referencePolicy": {
-              "type": "Source"
-            }
-          }
-        ]
       }
     },
     {

--- a/templates/s2i-app-build/template-no-secrets.json
+++ b/templates/s2i-app-build/template-no-secrets.json
@@ -13,6 +13,17 @@
     "objects": [
         {
             "apiVersion": "v1",
+            "kind": "ImageStream",
+            "metadata": {
+                "labels": {
+                    "build": "${NAME}"
+                },
+                "name": "${NAME}"
+            },
+            "spec": {}
+        },
+        {
+            "apiVersion": "v1",
             "kind": "BuildConfig",
             "metadata": {
                 "labels": {
@@ -86,17 +97,6 @@
             "status": {
                 "lastVersion": 1
             }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "ImageStream",
-            "metadata": {
-                "labels": {
-                    "build": "${NAME}"
-                },
-                "name": "${NAME}"
-            },
-            "spec": {}
         }
     ],
     "parameters": [

--- a/templates/s2i-app-build/template-with-secrets.json
+++ b/templates/s2i-app-build/template-with-secrets.json
@@ -13,6 +13,17 @@
     "objects": [
         {
             "apiVersion": "v1",
+            "kind": "ImageStream",
+            "metadata": {
+                "labels": {
+                    "build": "${NAME}"
+                },
+                "name": "${NAME}"
+            },
+            "spec": {}
+        },
+        {
+            "apiVersion": "v1",
             "kind": "BuildConfig",
             "metadata": {
                 "labels": {
@@ -90,17 +101,6 @@
             "status": {
                 "lastVersion": 1
             }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "ImageStream",
-            "metadata": {
-                "labels": {
-                    "build": "${NAME}"
-                },
-                "name": "${NAME}"
-            },
-            "spec": {}
         }
     ],
     "parameters": [

--- a/templates/sonarqube-aws/template.json
+++ b/templates/sonarqube-aws/template.json
@@ -8,6 +8,79 @@
   "objects": [
     {
       "apiVersion": "v1",
+      "kind": "ImageStream",
+      "metadata": {
+        "annotations": {
+          "openshift.io/generated-by": "OpenShiftNewApp"
+        },
+        "creationTimestamp": null,
+        "generation": 1,
+        "labels": {
+          "app": "sonarqube",
+          "appName": "sonarqube"
+        },
+        "name": "sonarqube"
+      },
+      "spec": {
+        "tags": [
+          {
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "sonarqube:latest"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "name": "latest",
+            "referencePolicy": {
+              "type": ""
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "ImageStream",
+      "metadata": {
+        "annotations": null,
+        "creationTimestamp": null,
+        "generation": 2,
+        "labels": {
+          "app": "sonarqube",
+          "appName": "sonarqube"
+        },
+        "name": "sonarqube"
+      },
+      "spec": {
+        "tags": [
+          {
+            "annotations": {
+              "openshift.io/generated-by": "OpenShiftWebConsole",
+              "openshift.io/imported-from": "sonarqube:latest"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "sonarqube:latest"
+            },
+            "generation": 2,
+            "importPolicy": {},
+            "name": "latest",
+            "referencePolicy": {
+              "type": "Source"
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "apiVersion": "v1",
       "kind": "PersistentVolumeClaim",
       "metadata": {
         "name": "sonarqube"
@@ -240,80 +313,7 @@
         },
         "wildcardPolicy": "None"
       }
-    },
-    {
-      "apiVersion": "v1",
-      "kind": "ImageStream",
-      "metadata": {
-        "annotations": {
-          "openshift.io/generated-by": "OpenShiftNewApp"
-        },
-        "creationTimestamp": null,
-        "generation": 1,
-        "labels": {
-          "app": "sonarqube",
-          "appName": "sonarqube"
-        },
-        "name": "sonarqube"
-      },
-      "spec": {
-        "tags": [
-          {
-            "annotations": null,
-            "from": {
-              "kind": "DockerImage",
-              "name": "sonarqube:latest"
-            },
-            "generation": null,
-            "importPolicy": {},
-            "name": "latest",
-            "referencePolicy": {
-              "type": ""
-            }
-          }
-        ]
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "apiVersion": "v1",
-      "kind": "ImageStream",
-      "metadata": {
-        "annotations": null,
-        "creationTimestamp": null,
-        "generation": 2,
-        "labels": {
-          "app": "sonarqube",
-          "appName": "sonarqube"
-        },
-        "name": "sonarqube"
-      },
-      "spec": {
-        "tags": [
-          {
-            "annotations": {
-              "openshift.io/generated-by": "OpenShiftWebConsole",
-              "openshift.io/imported-from": "sonarqube:latest"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "sonarqube:latest"
-            },
-            "generation": 2,
-            "importPolicy": {},
-            "name": "latest",
-            "referencePolicy": {
-              "type": "Source"
-            }
-          }
-        ]
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
+    }
     {
       "apiVersion": "v1",
       "kind": "Service",

--- a/templates/sonarqube/template.json
+++ b/templates/sonarqube/template.json
@@ -8,6 +8,79 @@
   "objects": [
     {
       "apiVersion": "v1",
+      "kind": "ImageStream",
+      "metadata": {
+        "annotations": {
+          "openshift.io/generated-by": "OpenShiftNewApp"
+        },
+        "creationTimestamp": null,
+        "generation": 1,
+        "labels": {
+          "app": "openshift-sonarqube",
+          "appName": "sonarqube"
+        },
+        "name": "openshift-sonarqube"
+      },
+      "spec": {
+        "tags": [
+          {
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift-sonarqube:latest"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "name": "latest",
+            "referencePolicy": {
+              "type": ""
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "ImageStream",
+      "metadata": {
+        "annotations": null,
+        "creationTimestamp": null,
+        "generation": 2,
+        "labels": {
+          "app": "sonarqube",
+          "appName": "sonarqube"
+        },
+        "name": "sonarqube"
+      },
+      "spec": {
+        "tags": [
+          {
+            "annotations": {
+              "openshift.io/generated-by": "OpenShiftWebConsole",
+              "openshift.io/imported-from": "sonarqube:latest"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "sonarqube:latest"
+            },
+            "generation": 2,
+            "importPolicy": {},
+            "name": "latest",
+            "referencePolicy": {
+              "type": "Source"
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "apiVersion": "v1",
       "kind": "PersistentVolumeClaim",
       "metadata": {
         "name": "openshift-sonarqube"
@@ -239,79 +312,6 @@
           "weight": 100
         },
         "wildcardPolicy": "None"
-      }
-    },
-    {
-      "apiVersion": "v1",
-      "kind": "ImageStream",
-      "metadata": {
-        "annotations": {
-          "openshift.io/generated-by": "OpenShiftNewApp"
-        },
-        "creationTimestamp": null,
-        "generation": 1,
-        "labels": {
-          "app": "openshift-sonarqube",
-          "appName": "sonarqube"
-        },
-        "name": "openshift-sonarqube"
-      },
-      "spec": {
-        "tags": [
-          {
-            "annotations": null,
-            "from": {
-              "kind": "DockerImage",
-              "name": "openshift-sonarqube:latest"
-            },
-            "generation": null,
-            "importPolicy": {},
-            "name": "latest",
-            "referencePolicy": {
-              "type": ""
-            }
-          }
-        ]
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "apiVersion": "v1",
-      "kind": "ImageStream",
-      "metadata": {
-        "annotations": null,
-        "creationTimestamp": null,
-        "generation": 2,
-        "labels": {
-          "app": "sonarqube",
-          "appName": "sonarqube"
-        },
-        "name": "sonarqube"
-      },
-      "spec": {
-        "tags": [
-          {
-            "annotations": {
-              "openshift.io/generated-by": "OpenShiftWebConsole",
-              "openshift.io/imported-from": "sonarqube:latest"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "sonarqube:latest"
-            },
-            "generation": 2,
-            "importPolicy": {},
-            "name": "latest",
-            "referencePolicy": {
-              "type": "Source"
-            }
-          }
-        ]
-      },
-      "status": {
-        "dockerImageRepository": ""
       }
     },
     {


### PR DESCRIPTION
Reordering ImageStreams before BuildConfig objects to avoid issues authenticating to Docker registry during image push.

It is important that ImageStreams be placed before BuildConfigs in order to properly attach the docker credentials to the destination registry. Otherwise a race condition will occur due to ImageStream resolution. If a build begins before resolving the destination, OpenShift will be unable to attach the proper .dockercfg secret which will result in an authentication error

This is being tracked in the following [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1443163) and discussed in an issue in [origin](https://github.com/openshift/origin/issues/4518)

CC: @sherl0cks @oybed 