### PR TITLE
Make disabling sonar more explicit

### DIFF
--- a/s2i-config/jenkins-master/configuration/init.groovy.d/configure-sonarqube.groovy
+++ b/s2i-config/jenkins-master/configuration/init.groovy.d/configure-sonarqube.groovy
@@ -13,7 +13,8 @@ import static hudson.plugins.sonar.utils.SQServerVersions.SQ_5_3_OR_HIGHER
 
 final def LOG = Logger.getLogger("LABS")
 
-if(System.getenv("DISABLE_SONAR") != null) {
+def disableSonar = System.getenv("DISABLE_SONAR");
+if(disableSonar != null && disableSonar.toUpperCase() == "TRUE") {
     LOG.log(Level.INFO, 'Skipping SonarQube configuration')
     return
 }


### PR DESCRIPTION
Disabling sonar should be more specific. If the parameter DISABLE_SONAR appears in OpenShift template with no value Jenkins interprets the value as not null. 

This PR changes that so that a deployment must explicitly set the DISABLE_SONAR to true for it to be disabled.


cc @oybed @sherl0cks 