### PR TITLE
support CI for the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 casl-ansible
 roles
+.idea
+*.iml
+gdsl

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,170 @@
+node() {
+    try {
+        stage('Initialization') {
+            env.OCP_API_SERVER = "${env.OPENSHIFT_API_URL}"
+            env.OCP_TOKEN = readFile('/var/run/secrets/kubernetes.io/serviceaccount/token').trim()
+        }
+
+        node('jenkins-slave-ansible') {
+
+            stage('Merge PR') {
+
+                sh '''
+                    git clone https://github.com/rht-labs/labs-ci-cd
+                    git config --global user.email "robot@example.com"
+                    git config --global user.name "A Robot"
+                '''
+
+                timeout(time: 1, unit: 'HOURS') {
+                    def userInput = input(
+                            id: 'userInput', message: 'Which PR # do you want to test?', parameters: [
+                            [$class: 'StringParameterDefinition', description: 'PR #', name: 'pr'],
+                            [$class: 'StringParameterDefinition', description: 'github token', name: 'token'],
+                            [$class: 'StringParameterDefinition', description: 'github user name', name: 'username']
+                    ])
+                    env.PR_ID = userInput['pr']
+                    env.PR_GITHUB_TOKEN = userInput['token']
+                    env.PR_GITHUB_USERNAME = userInput['username']
+
+
+                    if (env.PR_ID == null || env.PR_ID == ""){
+                        error('PR_ID cannot be null or empty')
+                    }
+                    if (env.PR_GITHUB_TOKEN == null || env.PR_GITHUB_TOKEN == ""){
+                        error('PR_GITHUB_TOKEN cannot be null or empty')
+                    }
+                    if (env.PR_GITHUB_USERNAME == null || env.PR_GITHUB_USERNAME == ""){
+                        error('PR_GITHUB_USERNAME cannot be null or empty')
+                    }
+                }
+
+                dir('labs-ci-cd') {
+
+                    String getCommitShaScript = """
+                        git fetch origin pull/${env.PR_ID}/head:pr
+                        git checkout pr
+                        git rev-parse HEAD
+                    """
+
+                    // set the vars
+                    env.COMMIT_SHA = sh(returnStdout: true, script: getCommitShaScript)
+                    env.USER_PASS = "${env.PR_GITHUB_USERNAME}:${env.PR_GITHUB_TOKEN}"
+                    env.PR_STATUS_URI = "https://api.github.com/repos/rht-labs/labs-ci-cd/statuses/${env.COMMIT_SHA}"
+
+
+                    def json = '''
+                        {
+                            "state": "pending",
+                            "description": "job is running...",
+                            "context": "Jenkins"
+                        }
+                    '''
+
+                    sh "curl -u ${env.USER_PASS} -d '${json}' -H 'Content-Type: application/json' -X POST ${env.PR_STATUS_URI}"
+
+
+                    sh """
+                        git checkout master
+                        git fetch origin pull/${env.PR_ID}/head:pr
+                        git merge pr --ff
+                    """
+                }
+
+
+            }
+
+            stage('Apply Inventory') {
+                dir('labs-ci-cd'){
+                    sh '''
+                        ansible-galaxy install -r requirements.yml --roles-path=roles
+                        git clone https://github.com/sherl0cks/labs-demo
+                        mv labs-demo/roles/make-demo-unique roles
+                        rm -rf labs-demo
+                        cp -r roles/casl-ansible/roles/* roles/
+                        ls roles/
+                    '''
+                    sh 'ansible-playbook ci-playbook.yaml -i inventory/'
+                }
+            }
+
+        }
+
+        stage('Verify Results') {
+            parallel(
+                    'CI Builds': {
+                        String[] builds = ['mvn-build-pod', 'npm-build-pod', 'zap-build-pod']
+
+                        for (String build : builds) {
+                            openshiftVerifyBuild(
+                                    apiURL: "${env.OCP_API_SERVER}",
+                                    authToken: "${env.OCP_TOKEN}",
+                                    buildConfig: build,
+                                    namespace: "labs-ci-cd-pr",
+                                    waitTime: '10',
+                                    waitUnit: 'min'
+                            )
+                        }
+                    },
+                    'CI Deploys': {
+                        String[] ciDeployments = ['jenkins', 'nexus', 'sonarqube']
+
+                        for (String deploy : ciDeployments) {
+                            openshiftVerifyDeployment(
+                                    apiURL: "${env.OCP_API_SERVER}",
+                                    authToken: "${env.OCP_TOKEN}",
+                                    depCfg: deploy,
+                                    namespace: "labs-ci-cd-pr",
+                                    verifyReplicaCount: true,
+                                    waitTime: '10',
+                                    waitUnit: 'min'
+                            )
+                        }
+                    },
+                    'App Deploys': {
+                        String[] appDeployments = ['java-app']
+
+                        for (String app : appDeployments) {
+                            openshiftVerifyDeployment(
+                                    apiURL: "${env.OCP_API_SERVER}",
+                                    authToken: "${env.OCP_TOKEN}",
+                                    depCfg: app,
+                                    namespace: "labs-dev-pr",
+                                    verifyReplicaCount: true,
+                                    waitTime: '10',
+                                    waitUnit: 'min'
+                            )
+                        }
+                    }, failFast: true
+            )
+
+            def json = '''\
+            {
+                "state": "success",
+                "description": "the job passed!",
+                "context": "Jenkins"
+            }'''
+
+            sh "curl -u ${env.USER_PASS} -d '${json}' -H 'Content-Type: application/json' -X POST ${env.PR_STATUS_URI}"
+        }
+
+    }
+    catch (e) {
+
+        // we don't have the info to post a status, so short circuit
+        if (env.COMMIT_SHA == null || env.COMMIT_SHA == "") {
+            error("The pull request ID ${env.PR_ID} is invalid.")
+        } else {
+
+            def json = '''
+            {
+                "state": "failure",
+                "description": "the job failed",
+                "context": "Jenkins"
+            }'''
+
+            sh "curl -u ${env.USER_PASS} -d '${json}' -H 'Content-Type: application/json' -X POST ${env.PR_STATUS_URI}"
+
+            throw e
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ See [the docs](https://github.com/redhat-cop/casl-ansible/tree/master/roles/open
 
 - S2I Build fails to push image to registry with `error: build error: Failed to push image: unauthorized: authentication required`
   - See [this issue](https://github.com/openshift/origin/issues/4518)
+  
+## Contributing
+
+1) Fork the repo and open PR's
+2) Add all new components to the inventory with appropriate namespaces and tags
+3) Extended the `Jenkinsfile` with steps to verify that your components built/deployed correctly
+4) For now, it is your responsibility to run the CI job
+
+### Running the CI job 
+
+1) Create a [GitHub OAuth](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) token to support commit status updates. You only need the privilege `repo:status`
+2) Apply the `labs-ci-cd` inventory to an OCP cluster, this will create a Jenkins job called `ci-for-labs-ci-cd`
+3) Run the `ci-for-labs-ci-cd` Jenkins job. It will prompt you for input. All fields are required.
+4) The job will update github with the result. If the build passes, your PR will be reviewed.
 
 ## License
 [ASL 2.0](LICENSE)

--- a/ci-playbook.yaml
+++ b/ci-playbook.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: seed-hosts[0]
+  vars:
+    demo_projectname: "pr"
+    scm_url: "this is only here to the role will run"
+    scm_ref: "this is only here to the role will run"
+  roles:
+    - make-demo-unique
+    - openshift-applier

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -46,6 +46,13 @@ openshift_cluster_content:
     namespace: labs-ci-cd
     tags:
     - jenkins-slaves
+  - name: jenkins-slave-ansible
+    template: "{{ inventory_dir }}/../openshift-templates/jenkins-slave-pod/template.json"
+    params: "{{ inventory_dir }}/../params/jenkins-slave-ansible/build"
+    namespace: labs-ci-cd
+    tags:
+      - jenkins-slaves
+      - ansible-slave
 - object: ci-cd-deployments
   content:
   - name: jenkins-ephemeral
@@ -71,7 +78,7 @@ openshift_cluster_content:
     params: "{{ inventory_dir }}/../params/sonarqube/postgresql"
     namespace: labs-ci-cd
     tags:
-    - sonar  
+    - sonar
 - object: app-builds
   content:
   - name: java-app-build
@@ -105,4 +112,12 @@ openshift_cluster_content:
     params: "{{ inventory_dir }}/../params/java-app/fabric8_demo"
     namespace: labs-demo
     tags:
-    - java-app  
+    - java-app
+- object: ci-for-labs-ci-cd
+  content:
+  - name: pipeline
+    template: "{{ inventory_dir }}/../openshift-templates/jenkins-pipeline-no-ocp-triggers/template.yaml"
+    params: "{{ inventory_dir }}/../params/ci-for-labs-ci-cd/build"
+    namespace: labs-ci-cd
+    tags:
+    - ci

--- a/openshift-templates/jenkins-pipeline-no-ocp-triggers/template.yaml
+++ b/openshift-templates/jenkins-pipeline-no-ocp-triggers/template.yaml
@@ -1,0 +1,49 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: jenkins-pipeline-no-ocp-triggers
+objects:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      build: "${NAME}"
+      name: "${NAME}-pipeline"
+    name: "${NAME}-pipeline"
+  spec:
+    runPolicy: Serial
+    source:
+      contextDir: "${PIPELINE_CONTEXT_DIR}"
+      git:
+        ref: "${PIPELINE_SOURCE_REPOSITORY_REF}"
+        uri: "${PIPELINE_SOURCE_REPOSITORY_URL}"
+      type: Git
+    strategy:
+      jenkinsPipelineStrategy:
+        jenkinsfilePath: "${PIPELINE_FILENAME}"
+      type: JenkinsPipeline
+parameters:
+- name: NAME
+  displayName: Name
+  description: The name assigned to all objects and the resulting imagestream.
+  required: true
+  value: s2i-app
+- name: PIPELINE_SOURCE_REPOSITORY_URL
+  displayName: Git Repository URL
+  description: The URL of the repository with your Jenkinsfile.
+  required: true
+- name: PIPELINE_FILENAME
+  displayName: Filename for the Jenkinsfle
+  description: Filename for the Jenkinsfle
+  required: true
+  value: Jenkinsfile
+- name: PIPELINE_SOURCE_REPOSITORY_REF
+  displayName: Git Reference
+  description: Set this to a branch name, tag or other ref of your repository if you
+    are not using the default (master) branch.
+  value: master
+- name: PIPELINE_CONTEXT_DIR
+  displayName: Git Context Directory for Jenkinsfile
+  description: Set this to the directory where the Jenkinsfile is if not using the
+    default root directory

--- a/openshift-templates/jenkins-slave-pod/template.json
+++ b/openshift-templates/jenkins-slave-pod/template.json
@@ -23,7 +23,7 @@
                     {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "openshift/jenkins-slave-base-rhel7:${SLAVE_IMAGE_TAG}"
+                            "name": "openshift3/jenkins-slave-base-rhel7:${SLAVE_IMAGE_TAG}"
                         },
                         "generation": 2,
                         "importPolicy": {},

--- a/openshift-templates/nexus/template.json
+++ b/openshift-templates/nexus/template.json
@@ -10,7 +10,7 @@
       "tags": "instant-app"
     },
     "labels": {
-      "app": "Nexus"
+      "app": "nexus"
     }
   },
   "objects": [
@@ -19,7 +19,8 @@
       "kind": "ImageStream",
       "metadata": {
         "labels": {
-          "name": "${NAME}"
+          "name": "${NAME}",
+          "app" : "${NAME}"
         },
         "name": "${NAME}"
       },
@@ -161,7 +162,8 @@
       "kind": "Service",
       "metadata": {
         "labels": {
-          "name": "${NAME}"
+          "name": "${NAME}",
+          "app" : "${NAME}"
         },
         "name": "${NAME}"
       },
@@ -185,7 +187,8 @@
       "kind": "Route",
       "metadata": {
         "labels": {
-          "name": "${NAME}"
+          "name": "${NAME}",
+          "app" : "${NAME}"
         },
         "name": "${NAME}"
       },
@@ -227,7 +230,7 @@
       "description": "The Container Image to use for the ImageStream",
       "displayName": "Nexus Container Image",
       "name": "CONTAINER_IMAGE",
-      "value": "sonatype/nexus3"
+      "value": "sonatype/nexus3:3.7.1"
     }
   ],
   "labels": {

--- a/params/ci-for-labs-ci-cd/build
+++ b/params/ci-for-labs-ci-cd/build
@@ -1,0 +1,3 @@
+NAME=ci-for-labs-ci-cd
+PIPELINE_SOURCE_REPOSITORY_REF=ci-for-labs-ci-cd
+PIPELINE_SOURCE_REPOSITORY_URL=https://github.com/sherl0cks/labs-ci-cd.git

--- a/params/java-app/build
+++ b/params/java-app/build
@@ -1,4 +1,4 @@
 PIPELINE_SOURCE_REPOSITORY_URL=https://github.com/rht-labs/automation-api
 PIPELINE_SOURCE_REPOSITORY_REF=dev-demo
 NAME=java-app
-S2I_BASE_IMAGE=redhat-openjdk18-openshift:latest
+S2I_BASE_IMAGE=redhat-openjdk18-openshift:1.2

--- a/params/jenkins-slave-ansible/build
+++ b/params/jenkins-slave-ansible/build
@@ -1,0 +1,5 @@
+SOURCE_REPOSITORY_URL=https://github.com/sherl0cks/labs-ci-cd
+SOURCE_CONTEXT_DIR=docker/jenkins-slave-ansible
+BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:latest
+NAME=jenkins-slave-ansible
+SOURCE_REPOSITORY_REF=ci-for-labs-ci-cd


### PR DESCRIPTION
adds a CI job via Jenkins / ocp-applier as well as docs.

partially addresses the need to pin down some versions, but not completely. will be merging this myself and then allow others to request changes or updates given how needed this is.