### PR TITLE
Repo fix for ansible Docker image

### DIFF
--- a/docker/jenkins-slave-ansible/Dockerfile
+++ b/docker/jenkins-slave-ansible/Dockerfile
@@ -5,7 +5,7 @@ USER root
 RUN yum repolist > /dev/null && \
     INSTALL_PKGS="ansible" && \
     yum install -y --setopt=tsflags=nodocs \
-      --enablerepo=rhel-7-server-extras-rpms \
+      --disablerepo=* --enablerepo=rhel-7-server-rpms --enablerepo=rhel-7-server-extras-rpms \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \

--- a/docker/jenkins-slave-ansible/Dockerfile
+++ b/docker/jenkins-slave-ansible/Dockerfile
@@ -2,8 +2,7 @@ FROM openshift3/jenkins-slave-base-rhel7:latest
 
 USER root
 
-RUN yum repolist > /dev/null && \
-    INSTALL_PKGS="ansible" && \
+RUN INSTALL_PKGS="ansible" && \
     yum install -y --setopt=tsflags=nodocs \
       --disablerepo=* --enablerepo=rhel-7-server-rpms --enablerepo=rhel-7-server-extras-rpms \
       $INSTALL_PKGS && \


### PR DESCRIPTION
The base image used for the Ansible Docker image has a lot of repos enabled that causes build issues; this PR disables all repos + enables the ones necessary for the build to succeed. 