### PR TITLE
explicitly setting Jenkins versions

### DIFF
--- a/params/jenkins/build
+++ b/params/jenkins/build
@@ -2,3 +2,4 @@ SOURCE_REPOSITORY_URL=https://github.com/rht-labs/labs-ci-cd.git
 NAME=jenkins
 SOURCE_REPOSITORY_REF=master
 SOURCE_REPOSITORY_CONTEXT_DIR=s2i-config/jenkins-master
+BUILDER_IMAGE_STREAM_TAG=jenkins:v3.7

--- a/params/jenkins/deploy
+++ b/params/jenkins/deploy
@@ -1,2 +1,3 @@
 NAMESPACE=labs-ci-cd
 MEMORY_LIMIT=2Gi
+JENKINS_IMAGE_STREAM_TAG=jenkins:latest


### PR DESCRIPTION
resolves #101 

default image tags have changed from `latest` => `2`, and `2` points to `3.6`. We need to set these explicitly
https://github.com/openshift/origin/blob/master/examples/jenkins/jenkins-ephemeral-template.json#L282

![screenshot from 2018-01-24 18-55-50](https://user-images.githubusercontent.com/1335137/35366750-3dc86eae-0138-11e8-84d5-004a5c9abe09.png)

