### PR TITLE
Update to npm build pod to include Chrome

### DIFF
--- a/docker/jenkins-slave-npm/Dockerfile
+++ b/docker/jenkins-slave-npm/Dockerfile
@@ -1,6 +1,12 @@
-#invoke npm in jenkinsfile: sh "scl enable rh-nodejs6 'npm run build'" 
+#invoke npm in jenkinsfile: sh "scl enable rh-nodejs6 'npm run build'"
 FROM openshift/jenkins-slave-nodejs-rhel7:latest
 USER root
+
+ADD https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm google-chrome-stable_current_x86_64.rpm
+RUN yum -y install redhat-lsb libXScrnSaver xdg-utils wget
+RUN yum -y localinstall google-chrome-stable_current_x86_64.rpm
+ENV CHROME_BIN /bin/google-chrome
+
 RUN yum remove -y rh-nodejs4; \
     yum repolist > /dev/null && \
     INSTALL_PKGS="rh-nodejs6 rh-nodejs6-npm rh-nodejs6-nodejs-nodemon nss_wrapper" && \
@@ -12,4 +18,5 @@ RUN yum remove -y rh-nodejs4; \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
     rm -rf /var/cache/yum
+
 USER 1001

--- a/docker/jenkins-slave-npm/README.md
+++ b/docker/jenkins-slave-npm/README.md
@@ -1,0 +1,15 @@
+# jenkins-slave-npm
+Provides a docker image of the nodejs v6 runtime with npm for use as a Jenkins slave. Also included is Chrome to enable headless testing as part of a CI build.
+
+## Build
+`docker build -t jenkins-slave-npm .`
+
+## Run
+For local running and experimentation run `docker run -i -t --rm jenkins-slave-npm /bin/bash` and have a play once inside the container.
+
+## Jenkins Running
+Add a new Kubernetes Container template called `jenkins-slave-npm` and specify this as the node when running builds. 
+```
+scl enable rh-nodejs6 'npm install'
+scl enable rh-nodejs6 'npm run build'
+```


### PR DESCRIPTION
Minor change to this build pod from our experience using it on residencies so far. We always had a need for Chrome headless when running unit tests as part of a build; so think it's likely others will need this too. 