### PR TITLE
Issue 154 nexus recreate deployment

### DIFF
--- a/openshift-templates/nexus/template.json
+++ b/openshift-templates/nexus/template.json
@@ -77,14 +77,7 @@
         "strategy": {
           "activeDeadlineSeconds": 21600,
           "resources": {},
-          "rollingParams": {
-            "intervalSeconds": 1,
-            "maxSurge": "25%",
-            "maxUnavailable": "25%",
-            "timeoutSeconds": 600,
-            "updatePeriodSeconds": 1
-          },
-          "type": "Rolling"
+          "type": "Recreate"
         },
         "template": {
           "metadata": {


### PR DESCRIPTION
The Nexus template uses "Rolling" deployment which means that it will try to start the replacement Pod before the it stops the existing Pod. Since Nexus uses a RWO PVC this Rolling deployment will fail. Changing it to use a Recreate deployment.