### PR TITLE
fixes apiVersion for hoverfly

### DIFF
--- a/openshift-templates/hoverfly/template.yaml
+++ b/openshift-templates/hoverfly/template.yaml
@@ -14,7 +14,7 @@ metadata:
     template.openshift.io/support-url: https://hoverfly.io
   name: hoverfly
 objects:
-- apiversion: v1
+- apiVersion: v1
   kind: Route
   metadata:
     name: ${HOVERFLY_SERVICE_NAME}


### PR DESCRIPTION
I ran into a error  on running `./run.sh`: Object 'apiVersion' is missing in 'object has no apiVersion field'.