### PR TITLE
ansible-galaxy run in a container for stability

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -4,5 +4,5 @@
 # From 'openshift-applier'
 - src: https://github.com/redhat-cop/openshift-applier
   scm: git
-  version: v3.7.2
+  version: v3.9.0
   name: openshift-applier

--- a/run.sh
+++ b/run.sh
@@ -43,12 +43,12 @@ else
     
 fi 
 
-DOCKER_RUN_COMMAND="yum -y install git && ansible-galaxy install -r /tmp/src/requirements.yml --roles-path=/tmp/src/galaxy && $DOCKER_RUN_COMMAND"
+DOCKER_RUN_COMMAND="ansible-galaxy install -r /tmp/src/requirements.yml --roles-path=/tmp/src/galaxy && $DOCKER_RUN_COMMAND"
 
 docker run --rm -i \
     -v $(pwd):/tmp/src:z \
     -v $HOME/.kube:/root/.kube:z \
-    -t redhatcop/openshift-applier \
+    -t redhatcop/openshift-applier:v3.9.0 \
     /bin/sh -c "$DOCKER_RUN_COMMAND"
 
 

--- a/run.sh
+++ b/run.sh
@@ -34,8 +34,6 @@ function printBanner(){
 ###########################
 printBanner
 
-ansible-galaxy install -r requirements.yml --roles-path=galaxy
-
 if [[ "$#" == 0 ]]; then
     DOCKER_RUN_COMMAND='ansible-playbook -i /tmp/src/inventory /tmp/src/galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml'
     printf "no arguments passed to run.sh. using default docker run command:\n- $DOCKER_RUN_COMMAND\n\n"
@@ -45,10 +43,12 @@ else
     
 fi 
 
+DOCKER_RUN_COMMAND="yum -y install git && ansible-galaxy install -r /tmp/src/requirements.yml --roles-path=/tmp/src/galaxy && $DOCKER_RUN_COMMAND"
+
 docker run --rm -i \
     -v $(pwd):/tmp/src:z \
     -v $HOME/.kube:/root/.kube:z \
     -t redhatcop/openshift-applier \
-    $DOCKER_RUN_COMMAND
+    /bin/sh -c "$DOCKER_RUN_COMMAND"
 
 


### PR DESCRIPTION
In the README document, the `run.sh` must need only docker runtime, but actually we need to install ansible-galaxy in a machine directly for executing `run.sh` .

I think `ansible-galaxy` should be run in a container same as `ansible-playbook` command.
