### PR TITLE
fixes a error on docker build on OpenShift.

### DIFF
--- a/docker/hoverfly/Dockerfile
+++ b/docker/hoverfly/Dockerfile
@@ -4,7 +4,8 @@ ENV PACKAGE_LIST less unzip
 ENV HOVERFLY_DOWNLOAD_URI https://github.com/SpectoLabs/hoverfly/releases/download/v0.14.2/hoverfly_bundle_linux_amd64.zip
 ENV HOME /home/hoverfly
 
-RUN yum install -y $PACKAGE_LIST && \
+RUN yum-config-manager --disable rhel-7-server-htb-rpms && \
+    yum install -y $PACKAGE_LIST && \
     rpm -V $PACKAGE_LIST && \
     yum clean all -y && \
     curl -o /tmp/hoverfly.zip -L $HOVERFLY_DOWNLOAD_URI && \

--- a/docker/jenkins-slave-ansible/Dockerfile
+++ b/docker/jenkins-slave-ansible/Dockerfile
@@ -4,7 +4,8 @@ USER root
 
 # Current we need ansible 2.5 which is not yet release
 # https://github.com/rht-labs/labs-ci-cd/issues/138 exists to move back to a RHEL supported ansible install once 2.5 is released
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; \
+RUN yum-config-manager --disable rhel-7-server-htb-rpms && \
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; \
     yum install -y python-pip git; \
     pip install --upgrade pip;  \
     pip install git+https://github.com/ansible/ansible.git@stable-2.5 && \


### PR DESCRIPTION
I've find a error that occurred on building `hoverfly` and `jenkins-slave-ansible` image on OCP.
I'm not sure that fixes is the best way, but it fixes the problems.
Would you please check the issue? I attached the error I've got.

```

Loaded plugins: ovl, product-id, search-disabled-repos, subscription-manager
--
  | https://cdn.redhat.com/content/htb/rhel/server/7/x86_64/os/repodata/repomd.xml:  [Errno 14] HTTPS Error 403 - Forbidden
  | Trying other mirror.
  | To address this issue please refer to the below knowledge base article
  |  
  | https://access.redhat.com/solutions/69319
  |  
  | If above article doesn't help to resolve this issue please open a ticket with Red Hat Support.
  |  
  |  
  |  
  | One of the configured repositories failed (Red Hat Enterprise Linux 7 Server HTB (RPMs)),
  | and yum doesn't have enough cached data to continue. At this point the only
  | safe thing yum can do is fail. There are a few ways to work "fix" this:
  |  
  | 1. Contact the upstream for the repository and get them to fix the problem.
  |  
  | 2. Reconfigure the baseurl/etc. for the repository, to point to a working
  | upstream. This is most often useful if you are using a newer
  | distribution release than is supported by the repository (and the
  | packages for the previous distribution release still work).
  |  
  | 3. Run the command with the repository temporarily disabled
  | yum --disablerepo=rhel-7-server-htb-rpms ...
  |  
  | 4. Disable the repository permanently, so yum won't use it by default. Yum
  | will then just ignore the repository until you permanently enable it
  | again or use --enablerepo for temporary usage:
  |  
  | yum-config-manager --disable rhel-7-server-htb-rpms
  | or
  | subscription-manager repos --disable=rhel-7-server-htb-rpms
  |  
  | 5. Configure the failing repository to be skipped, if it is unavailable.
  | Note that yum will try to contact the repo. when it runs most commands,
  | so will have to try and fail each time (and thus. yum will be be much
  | slower). If it is a very temporary problem though, this is often a nice
  | compromise:
  |  
  | yum-config-manager --save --setopt=rhel-7-server-htb-rpms.skip_if_unavailable=true
  |  
  | failure: repodata/repomd.xml from rhel-7-server-htb-rpms: [Errno 256] No more mirrors to try.
  | https://cdn.redhat.com/content/htb/rhel/server/7/x86_64/os/repodata/repomd.xml:  [Errno 14] HTTPS Error 403 - Forbidden
  | Removing intermediate container 07f6d623b2c1
  | error: build error: The command '/bin/sh -c yum install -y $PACKAGE_LIST &&     rpm -V $PACKAGE_LIST &&     yum clean all -y &&     curl -o /tmp/hoverfly.zip -L $HOVERFLY_DOWNLOAD_URI &&     unzip /tmp/hoverfly.zip -d /tmp/hoverfly &&     mv /tmp/hoverfly/hover* /usr/bin &&     rm -r /tmp/hoverfly /tmp/hoverfly.zip &&     mkdir -m 775 $HOME &&     chmod 775 /etc/passwd' returned a non-zero code: 1
```