### PR TITLE
Change path for SonarQube health checks

### DIFF
--- a/openshift-templates/sonarqube/template.yaml
+++ b/openshift-templates/sonarqube/template.yaml
@@ -294,7 +294,7 @@ objects:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /
+              path: /api/system/health
               port: 9000
               scheme: HTTP
             initialDelaySeconds: 45
@@ -308,7 +308,7 @@ objects:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /
+              path: /api/system/health
               port: 9000
               scheme: HTTP
             initialDelaySeconds: 10


### PR DESCRIPTION
The SonarQube docs recommend using `/api/system/health` for health checks to be reliable.