### PR TITLE
Add Jenkins Python 3.6 slave definitions

### DIFF
--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -80,6 +80,13 @@ openshift_cluster_content:
     tags:
       - jenkins-slaves
       - mongodb-slave
+  - name: jenkins-slave-python
+    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.1/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    params: "{{ playbook_dir }}/params/jenkins-slaves/python"
+    namespace: "{{ ci_cd_namespace }}"
+    tags:
+      - jenkins-slaves
+      - python-slave
 - object: ci-cd-deployments
   content:
   - name: sonarqube

--- a/params/jenkins-slaves/python
+++ b/params/jenkins-slaves/python
@@ -2,4 +2,4 @@ SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/containers-quickstarts.git
 SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-python
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-maven-rhel7:latest
 NAME=jenkins-slave-python
-SOURCE_REPOSITORY_REF=add-python-slave
+SOURCE_REPOSITORY_REF=master

--- a/params/jenkins-slaves/python
+++ b/params/jenkins-slaves/python
@@ -1,0 +1,5 @@
+SOURCE_REPOSITORY_URL=https://github.com/jacobsee/containers-quickstarts.git
+SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-python
+BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-maven-rhel7:latest
+NAME=jenkins-slave-python
+SOURCE_REPOSITORY_REF=add-python-slave

--- a/params/jenkins-slaves/python
+++ b/params/jenkins-slaves/python
@@ -1,4 +1,4 @@
-SOURCE_REPOSITORY_URL=https://github.com/jacobsee/containers-quickstarts.git
+SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/containers-quickstarts.git
 SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-python
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-maven-rhel7:latest
 NAME=jenkins-slave-python


### PR DESCRIPTION
Adds configs to deploy Python 3.6 slaves to labs-ci-cd. References redhat-cop/container-quickstarts, and will only function correctly when https://github.com/redhat-cop/containers-quickstarts/pull/126 is merged.