### PR TITLE
Fix stringbuilder error

### DIFF
--- a/s2i-config/jenkins-master/configuration/init.groovy.d/configure-jenkins.groovy
+++ b/s2i-config/jenkins-master/configuration/init.groovy.d/configure-jenkins.groovy
@@ -59,7 +59,7 @@ proc.waitForOrKill(3000)
 println "out> $sout2 err> $serr2"
 
 def jlc = jenkins.model.JenkinsLocationConfiguration.get()
-jlc.setUrl("https://" + sout2.trim())
+jlc.setUrl("https://" + sout2.toString().trim())
 
 println("Configuring container cap for k8s, so pipelines won't hang when booting up slaves")
 


### PR DESCRIPTION
An error was introduced with this commit https://github.com/rht-labs/labs-ci-cd/commit/13220d163e7e38674b00b560d39387d3b3ed0269 when the configure-jenkins.groovy would through an error when setting the jenkins url.

This PR fixes the error

```

WARNING: Failed to run script file:/var/lib/jenkins/init.groovy.d/configure-jenkins.groovy
--
  | groovy.lang.MissingMethodException: No signature of method: java.lang.StringBuilder.trim() is applicable for argument types: () values: []
  | Possible solutions: tr(java.lang.CharSequence, java.lang.CharSequence), wait(), grep(), wait(long), grep(java.lang.Object), drop(int)
  | at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:58)
  | at org.codehaus.groovy.runtime.callsite.PojoMetaClassSite.call(PojoMetaClassSite.java:49)
  | at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
  | at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
  | at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:117)
  | at configure-jenkins.run(configure-jenkins.groovy:62)
```
@pcarney8 