### PR TITLE
Fixing hoverfly

### DIFF
--- a/openshift-templates/hoverfly/template.yml
+++ b/openshift-templates/hoverfly/template.yml
@@ -69,11 +69,36 @@ objects:
         containers:
         - name: ${HOVERFLY_SERVICE_NAME}
           image: ' '
+          command:
+            - 'hoverfly'
+          args:
+            - '-listen-on-host'
+            - '0.0.0.0'
           ports:
             - containerPort: 8500
               protocol: TCP
             - containerPort: 8888
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8888
+              scheme: HTTP
+            initialDelaySeconds: 120
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8888
+              scheme: HTTP
+            initialDelaySeconds: 20
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             limits:
               memory: ${MEMORY_LIMIT}


### PR DESCRIPTION
It looks like we previously removed the livenessprobe and readinessprobe from hoverfly because they were causing failures. These failures were caused due to the fact that hoverfly was only listening on the loopback address. This PR fixes this by passing in the appropriate args to have hoverfly listen on all interfaces.