### PR TITLE
Fix sonar configuration for plugin version 2.8

### DIFF
--- a/s2i-config/jenkins-master/configuration/init.groovy.d/configure-jenkins.groovy
+++ b/s2i-config/jenkins-master/configuration/init.groovy.d/configure-jenkins.groovy
@@ -6,7 +6,6 @@ import hudson.tools.InstallSourceProperty
 
 import java.util.logging.Level
 import java.util.logging.Logger
-import static hudson.plugins.sonar.utils.SQServerVersions.SQ_5_3_OR_HIGHER
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud
 import jenkins.model.JenkinsLocationConfiguration
 

--- a/s2i-config/jenkins-master/configuration/init.groovy.d/configure-sonarqube.groovy
+++ b/s2i-config/jenkins-master/configuration/init.groovy.d/configure-sonarqube.groovy
@@ -9,7 +9,6 @@ import hudson.tools.InstallSourceProperty
 
 import java.util.logging.Level
 import java.util.logging.Logger
-import static hudson.plugins.sonar.utils.SQServerVersions.SQ_5_3_OR_HIGHER
 
 final def LOG = Logger.getLogger("LABS")
 
@@ -64,8 +63,7 @@ if (rc == 200) {
 
     // Add the SonarQube server config to Jenkins
     SonarInstallation sonarInst = new SonarInstallation(
-        "sonar", sonarHost, SQ_5_3_OR_HIGHER, token, "", "", "", "", "", new TriggersConfig(), "", "", ""
-    )
+        "sonar", sonarHost, token, "", "", new TriggersConfig(), "")
     sonarConfig.setInstallations(sonarInst)
     sonarConfig.setBuildWrapperEnabled(true)
     sonarConfig.save()


### PR DESCRIPTION
The sonar plugin refactored a lot of code between versions 2.6 and 2.8 including the removal of support for versions prior to 5.6. This caused breaking changes for us. Also removes unused sonar reference from the configure-jenkins.groovy script.

Resolves #214. 

Note this conflicts with PR #218 which reverts the plugin to 2.6. This fix supports the sonar plugin version 2.8