### PR TITLE
Add name 'jolokia' for 8778 port to enable Hawt.io console access for Java apps

### DIFF
--- a/openshift-templates/automation-api-hsql/template.yml
+++ b/openshift-templates/automation-api-hsql/template.yml
@@ -51,6 +51,7 @@ objects:
           ports:
           - containerPort: 8778
             protocol: TCP
+            name: jolokia
           - containerPort: 8080
             protocol: TCP
           - containerPort: 8443


### PR DESCRIPTION
For OpenShift to expose the Hawt.io console for Java application containers, the port 8778 MUST have the name 'jolokia' in the DeploymentConfig. Adding that name creates a link on the Pod page in OpenShift which will open the Hawt.io console.