### PR TITLE
Update applier to latest version

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -4,5 +4,5 @@
 # From 'openshift-applier'
 - src: https://github.com/redhat-cop/openshift-applier
   scm: git
-  version: v2.0.5
+  version: v2.0.6
   name: openshift-applier

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,5 +4,5 @@
 # From 'openshift-applier'
 - src: https://github.com/redhat-cop/openshift-applier
   scm: git
-  version: v2.0.2
+  version: v2.0.5
   name: openshift-applier

--- a/run.sh
+++ b/run.sh
@@ -48,7 +48,7 @@ DOCKER_RUN_COMMAND="ansible-galaxy install -r /tmp/src/requirements.yml --roles-
 docker run --rm -i \
     -v $(pwd):/tmp/src:z \
     -v $HOME/.kube:/root/.kube:z \
-    -t quay.io/redhat-cop/openshift-applier:v2.0.5 \
+    -t quay.io/redhat-cop/openshift-applier:v2.0.6 \
     /bin/sh -c "$DOCKER_RUN_COMMAND"
 
 

--- a/run.sh
+++ b/run.sh
@@ -48,7 +48,7 @@ DOCKER_RUN_COMMAND="ansible-galaxy install -r /tmp/src/requirements.yml --roles-
 docker run --rm -i \
     -v $(pwd):/tmp/src:z \
     -v $HOME/.kube:/root/.kube:z \
-    -t redhatcop/openshift-applier:v2.0.5 \
+    -t quay.io/redhat-cop/openshift-applier:v2.0.5 \
     /bin/sh -c "$DOCKER_RUN_COMMAND"
 
 

--- a/run.sh
+++ b/run.sh
@@ -48,7 +48,7 @@ DOCKER_RUN_COMMAND="ansible-galaxy install -r /tmp/src/requirements.yml --roles-
 docker run --rm -i \
     -v $(pwd):/tmp/src:z \
     -v $HOME/.kube:/root/.kube:z \
-    -t redhatcop/openshift-applier:v3.9.0 \
+    -t redhatcop/openshift-applier:v2.0.5 \
     /bin/sh -c "$DOCKER_RUN_COMMAND"
 
 


### PR DESCRIPTION
The version in `run.sh` was actually a couple of major versions behind. Now both `requirements.yml` and `run.sh` point to v2.0.5.