### PR TITLE
Fix typo in filter_tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If not using docker or `./run.sh`, here is the same example:
 ```bash
 ansible-playbook  apply.yml \
     -e target=tools \
-    -e="filter_tags=jenkins,ci,projects"
+    -e "filter_tags=jenkins,ci,projects"
 ```
 
 ## Scope and Direction


### PR DESCRIPTION
There's an extra `=` in one of the example commands in the readme, which prevents `filter_tags` from working properly. Related: #238