### PR TITLE
Update to newer versions of Nexus and infra-ansible

### DIFF
--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -166,6 +166,7 @@ openshift_cluster_content:
     params_from_vars:
       VOLUME_CAPACITY: 10Gi
       MEMORY_LIMIT: 2Gi
+      CONTAINER_IMAGE: sonatype/nexus3:3.15.2
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - nexus

--- a/requirements.yml
+++ b/requirements.yml
@@ -8,5 +8,5 @@
   name: openshift-applier
 - src: https://github.com/redhat-cop/infra-ansible
   scm: git
-  version: v1.0.6
+  version: v1.0.9
   name: infra-ansible

--- a/site.yml
+++ b/site.yml
@@ -17,6 +17,7 @@
         nexus_namespace: "{{ ci_cd_namespace }}"
         nexus_user: "admin"
         nexus_password: "admin123"
+        nexus_api_base_path: /service/rest/v1
     - include_role:
         name: roles/infra-ansible/roles/config-nexus
       tags:


### PR DESCRIPTION
Resolves #256 

Updates Labs CI/CD to use newer release of the `config-nexus` role from redhat-cop/infra-ansible 1.0.9 and use Nexus 3.15.2.