### PR TITLE
Update to used mended version of openshift-labels roles

### DIFF
--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -156,19 +156,19 @@ openshift_cluster_content:
     post_steps:
     - role: casl-ansible/roles/openshift-labels
       vars:
-        target_namespace: "-n {{ ci_cd_namespace }}"
+        target_namespace: "{{ ci_cd_namespace }}"
         label: "app=sonarqube"
         target_object: dc
         target_name: sonardb
     - role: casl-ansible/roles/openshift-labels
       vars:
-        target_namespace: "-n {{ ci_cd_namespace }}"
+        target_namespace: "{{ ci_cd_namespace }}"
         label: "app=sonarqube"
         target_object: svc
         target_name: sonardb
     - role: casl-ansible/roles/openshift-labels
       vars:
-        target_namespace: "-n {{ ci_cd_namespace }}"
+        target_namespace: "{{ ci_cd_namespace }}"
         label: "app=sonarqube"
         target_object: secret
         target_name: sonardb

--- a/pre_post_requirements.yml
+++ b/pre_post_requirements.yml
@@ -1,4 +1,4 @@
 - src: https://github.com/redhat-cop/casl-ansible
   scm: git
-  version: v3.11.1
+  version: v3.11.2
   name: casl-ansible


### PR DESCRIPTION
This fixes the need to have the `-n ` in the namespace parameter for the post step which labels the SonarQube database.