### PR TITLE
Collection of updates from past few customers

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -24,5 +24,5 @@ edit_role_binding_group:
   GROUP: "labs-ci-cd-contributors"
   ROLE: "{{ role | default('edit') }}"
 admin_role_binding_group:
-  GROUP: "ocp-admins"
+  GROUP: "ocp-devs"
   ROLE: "admin"

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -4,6 +4,7 @@ test_namespace: labs-test
 
 # When the ocp_templates gets moved to cop land we can merge the two raws below
 openshift_templates_raw: "https://raw.githubusercontent.com/rht-labs/openshift-templates"
+openshift_templates_raw_version_tag: "v1.3"
 cop_quickstarts: "https://github.com/redhat-cop/containers-quickstarts.git"
 cop_quickstarts_raw: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts"
 

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -2,6 +2,11 @@ ci_cd_namespace: labs-ci-cd
 dev_namespace: labs-dev
 test_namespace: labs-test
 
+# When the ocp_templates gets moved to cop land we can merge the two raws below
+openshift_templates_raw: "https://raw.githubusercontent.com/rht-labs/openshift-templates"
+cop_quickstarts: "https://github.com/redhat-cop/containers-quickstarts.git"
+cop_quickstarts_raw: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts"
+
 ci_cd:
   NAMESPACE: "{{ ci_cd_namespace }}"
   NAMESPACE_DISPLAY_NAME: "{{ ci_cd_namespace }}"

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -7,6 +7,7 @@ openshift_templates_raw: "https://raw.githubusercontent.com/rht-labs/openshift-t
 openshift_templates_raw_version_tag: "v1.3"
 cop_quickstarts: "https://github.com/redhat-cop/containers-quickstarts.git"
 cop_quickstarts_raw: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts"
+cop_quickstarts_raw_version_tag: "v1.9"
 
 ci_cd:
   NAMESPACE: "{{ ci_cd_namespace }}"

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -20,6 +20,9 @@ test:
   NAMESPACE: "{{ test_namespace }}"
   NAMESPACE_DISPLAY_NAME: "{{ test_namespace }}"
 
-role_binding_group:
+edit_role_binding_group:
   GROUP: "labs-ci-cd-contributors"
   ROLE: "{{ role | default('edit') }}"
+admin_role_binding_group:
+  GROUP: "ocp-admins"
+  ROLE: "admin"

--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -10,7 +10,7 @@ jenkins:
   build:
     NAME: "{{ jenkins_name }}"
     SOURCE_REPOSITORY_URL: https://github.com/rht-labs/s2i-config-jenkins.git
-    SOURCE_REPOSITORY_REF: v1.3
+    SOURCE_REPOSITORY_REF: v1.4
     BUILDER_IMAGE_STREAM_NAME: jenkins-2-rhel7
     BUILDER_IMAGE_STREAM_TAG_NAME: v3.11
     IMAGE_STREAM_NAMESPACE: "{{ ci_cd_namespace }}"
@@ -43,7 +43,7 @@ nexus:
 sonarqube:
   build:
     NAME: "{{ sonarqube_name }}"
-    SOURCE_REPOSITORY_URL: {{ cop_quickstarts }}
+    SOURCE_REPOSITORY_URL: "{{ cop_quickstarts }}"
     SOURCE_REPOSITORY_REF: v1.4
     SOURCE_CONTEXT_DIR: sonarqube
   postgresql:
@@ -58,7 +58,7 @@ sonarqube:
 hoverfly:
   build:
     NAME: "{{ hoverfly_name }}"
-    SOURCE_REPOSITORY_URL: {{ cop_quickstarts }}
+    SOURCE_REPOSITORY_URL: "{{ cop_quickstarts }}"
     SOURCE_REPOSITORY_REF: v1.4
     SOURCE_CONTEXT_DIR: hoverfly
   deploy:
@@ -85,7 +85,7 @@ openshift_cluster_content:
     template: "{{ cop_quickstarts_raw }}/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
     params_from_vars:
       NAME: tool-box
-      SOURCE_REPOSITORY_URL: {{ cop_quickstarts }}
+      SOURCE_REPOSITORY_URL: "{{ cop_quickstarts }}"
       SOURCE_REPOSITORY_REF: v1.1
       SOURCE_CONTEXT_DIR: tool-box
     namespace: "{{ ci_cd_namespace }}"

--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -26,6 +26,9 @@ jenkins:
     VOLUME_CAPACITY: 20Gi
     MEMORY_REQUEST: 2Gi
     JVM_ARCH: x86_64
+    GITLAB_HOST: "gitlab.mydomain.example.com"
+    GITLAB_TOKEN: "token123"
+    GITLAB_GROUP_NAME: "rht-labs"
 
 nexus:
   secret:

--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -44,7 +44,7 @@ sonarqube:
   build:
     NAME: "{{ sonarqube_name }}"
     SOURCE_REPOSITORY_URL: "{{ cop_quickstarts }}"
-    SOURCE_REPOSITORY_REF: v1.4
+    SOURCE_REPOSITORY_REF: "{{ cop_quickstarts_raw_version_tag }}"
     SOURCE_CONTEXT_DIR: sonarqube
   postgresql:
     POSTGRESQL_DATABASE: sonar
@@ -67,7 +67,7 @@ hoverfly:
   build:
     NAME: "{{ hoverfly_name }}"
     SOURCE_REPOSITORY_URL: "{{ cop_quickstarts }}"
-    SOURCE_REPOSITORY_REF: v1.4
+    SOURCE_REPOSITORY_REF: "{{ cop_quickstarts_raw_version_tag }}"
     SOURCE_CONTEXT_DIR: hoverfly
   deploy:
     NAMESPACE: "{{ ci_cd_namespace }}"
@@ -94,7 +94,7 @@ openshift_cluster_content:
     - jenkins-build
     - ci-cd-builds
   - name: tool-box
-    template: "{{ cop_quickstarts_raw }}/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/build-docker-generic/.openshift/templates/docker-build-template.yml"
     params_from_vars:
       NAME: tool-box
       SOURCE_REPOSITORY_URL: "{{ cop_quickstarts }}"
@@ -105,14 +105,14 @@ openshift_cluster_content:
     - tool-box
     - ci-cd-builds
   - name: hoverfly
-    template: "{{ cop_quickstarts_raw }}/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/build-docker-generic/.openshift/templates/docker-build-template.yml"
     params_from_vars: "{{ hoverfly.build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
     - hoverfly
     - ci-cd-builds
   - name: sonarqube
-    template: "{{ cop_quickstarts_raw }}/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/build-docker-generic/.openshift/templates/docker-build-template.yml"
     params_from_vars: "{{ sonarqube.build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -152,63 +152,63 @@ openshift_cluster_content:
 - object: jenkins-slave-nodes
   content:
   - name: jenkins-slave-mvn
-    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/jenkins-slaves/.openshift/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/mvn"
     namespace: "{{ ci_cd_namespace }}"
     tags:
     - jenkins-slaves
     - mvn-slave
   - name: jenkins-slave-npm
-    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/jenkins-slaves/.openshift/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/npm"
     namespace: "{{ ci_cd_namespace }}"
     tags:
     - jenkins-slaves
     - npm-slave
   - name: jenkins-slave-zap
-    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/jenkins-slaves/.openshift/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/zap"
     namespace: "{{ ci_cd_namespace }}"
     tags:
     - jenkins-slaves
     - zap-slave
   - name: jenkins-slave-ansible
-    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/jenkins-slaves/.openshift/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/ansible"
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - jenkins-slaves
       - ansible-slave
   - name: jenkins-slave-arachni
-    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/jenkins-slaves/.openshift/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/arachni"
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - jenkins-slaves
       - arachni-slave
   - name: jenkins-slave-gradle
-    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/jenkins-slaves/.openshift/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/gradle"
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - jenkins-slaves
       - gradle-slave
   - name: jenkins-slave-golang
-    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/jenkins-slaves/.openshift/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/golang"
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - jenkins-slaves
       - golang-slave
   - name: jenkins-slave-mongodb
-    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/jenkins-slaves/.openshift/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/mongodb"
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - jenkins-slaves
       - mongodb-slave
   - name: jenkins-slave-python
-    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/jenkins-slaves/.openshift/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/python"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -248,7 +248,7 @@ openshift_cluster_content:
       - sonarqube-postgresql-deploy
       - ci-cd-deployments
   - name: sonarqube
-    template: "{{ cop_quickstarts_raw }}/v1.6/sonarqube/.openshift/templates/sonarqube-deployment-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/sonarqube/.openshift/templates/sonarqube-deployment-template.yml"
     params_from_vars: "{{ sonarqube.deploy }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -290,7 +290,7 @@ openshift_cluster_content:
       - jenkins-persistent
       - ci-cd-deployments
   - name: zalenium
-    template: "{{ cop_quickstarts_raw }}/v1.9/zalenium/.openshift/templates/zalenium-deployment.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/zalenium/.openshift/templates/zalenium-deployment.yml"
     params_from_vars: "{{ zalenium }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -298,7 +298,7 @@ openshift_cluster_content:
       - zalenium-deploy
       - ci-cd-deployments
   - name: hoverfly
-    template: "{{ cop_quickstarts_raw }}/v1.4/hoverfly/.openshift/templates/hoverfly-deployment-template.yml"
+    template: "{{ cop_quickstarts_raw }}/{{ cop_quickstarts_raw_version_tag }}/hoverfly/.openshift/templates/hoverfly-deployment-template.yml"
     params_from_vars: "{{ hoverfly.deploy }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:

--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -40,7 +40,7 @@ nexus:
 sonarqube:
   build:
     NAME: "{{ sonarqube_name }}"
-    SOURCE_REPOSITORY_URL: https://github.com/redhat-cop/containers-quickstarts.git
+    SOURCE_REPOSITORY_URL: {{ cop_quickstarts }}
     SOURCE_REPOSITORY_REF: v1.4
     SOURCE_CONTEXT_DIR: sonarqube
   postgresql:
@@ -55,7 +55,7 @@ sonarqube:
 hoverfly:
   build:
     NAME: "{{ hoverfly_name }}"
-    SOURCE_REPOSITORY_URL: https://github.com/redhat-cop/containers-quickstarts.git
+    SOURCE_REPOSITORY_URL: {{ cop_quickstarts }}
     SOURCE_REPOSITORY_REF: v1.4
     SOURCE_CONTEXT_DIR: hoverfly
   deploy:
@@ -71,7 +71,7 @@ openshift_cluster_content:
 - object: ci-cd-builds
   content:
   - name: jenkins-s2i
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/jenkins-s2i-build/jenkins-s2i-build-template.yml"
+    template: "{{ openshift_templates_raw }}/v1.0/jenkins-s2i-build/jenkins-s2i-build-template.yml"
     params_from_vars: "{{ jenkins.build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -79,10 +79,10 @@ openshift_cluster_content:
     - jenkins-build
     - ci-cd-builds
   - name: tool-box
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
     params_from_vars:
       NAME: tool-box
-      SOURCE_REPOSITORY_URL: https://github.com/redhat-cop/containers-quickstarts.git
+      SOURCE_REPOSITORY_URL: {{ cop_quickstarts }}
       SOURCE_REPOSITORY_REF: v1.1
       SOURCE_CONTEXT_DIR: tool-box
     namespace: "{{ ci_cd_namespace }}"
@@ -90,14 +90,14 @@ openshift_cluster_content:
     - tool-box
     - ci-cd-builds
   - name: hoverfly
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
     params_from_vars: "{{ hoverfly.build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
     - hoverfly
     - ci-cd-builds
   - name: sonarqube
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
     params_from_vars: "{{ sonarqube.build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -109,7 +109,7 @@ openshift_cluster_content:
 - object: ci-cd-secrets
   content:
   - name: nexus-secret
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/master/secrets/secret-user-pass-plaintext.yml"
+    template: "{{ openshift_templates_raw }}/v1.2/secrets/secret-user-pass-plaintext.yml"
     params_from_vars: "{{ nexus.secret }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -117,7 +117,7 @@ openshift_cluster_content:
     - secret
     - ci-cd-secrets
   - name: jenkins-secret
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/master/secrets/secret-user-pass-plaintext.yml"
+    template: "{{ openshift_templates_raw }}/v1.2/secrets/secret-user-pass-plaintext.yml"
     params_from_vars: "{{ jenkins.build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -129,63 +129,63 @@ openshift_cluster_content:
 - object: jenkins-slave-nodes
   content:
   - name: jenkins-slave-mvn
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/mvn"
     namespace: "{{ ci_cd_namespace }}"
     tags:
     - jenkins-slaves
     - mvn-slave
   - name: jenkins-slave-npm
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/npm"
     namespace: "{{ ci_cd_namespace }}"
     tags:
     - jenkins-slaves
     - npm-slave
   - name: jenkins-slave-zap
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/zap"
     namespace: "{{ ci_cd_namespace }}"
     tags:
     - jenkins-slaves
     - zap-slave
   - name: jenkins-slave-ansible
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/ansible"
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - jenkins-slaves
       - ansible-slave
   - name: jenkins-slave-arachni
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/arachni"
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - jenkins-slaves
       - arachni-slave
   - name: jenkins-slave-gradle
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/gradle"
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - jenkins-slaves
       - gradle-slave
   - name: jenkins-slave-golang
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/golang"
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - jenkins-slaves
       - golang-slave
   - name: jenkins-slave-mongodb
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/mongodb"
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - jenkins-slaves
       - mongodb-slave
   - name: jenkins-slave-python
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.3/jenkins-slaves/templates/jenkins-slave-generic-template.yml"
     params: "{{ inventory_dir }}/../params/jenkins-slaves/python"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -225,7 +225,7 @@ openshift_cluster_content:
       - sonarqube-postgresql-deploy
       - ci-cd-deployments
   - name: sonarqube
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.6/sonarqube/.openshift/templates/sonarqube-deployment-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.6/sonarqube/.openshift/templates/sonarqube-deployment-template.yml"
     params_from_vars: "{{ sonarqube.deploy }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -233,7 +233,7 @@ openshift_cluster_content:
       - sonarqube-deploy
       - ci-cd-deployments
   - name: nexus
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/nexus/nexus-deployment-template.yml"
+    template: "{{ openshift_templates_raw }}/v1.0/nexus/nexus-deployment-template.yml"
     params_from_vars: "{{ nexus.deploy }}"
     namespace: "{{ ci_cd_namespace }}"
     post_steps:
@@ -249,7 +249,7 @@ openshift_cluster_content:
       - ci-cd-deployments
   #  Want to use Ephemeral Jenkins? Just swap out these two lines
   # - name: jenkins-ephemeral
-  #   template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/jenkins/jenkins-ephemeral-template.yml"
+  #   template: "{{ openshift_templates_raw }}/v1.0/jenkins/jenkins-ephemeral-template.yml"
   #   params_from_vars: "{{ jenkins.deploy }}"
   #   namespace: "{{ ci_cd_namespace }}"
   #   tags:
@@ -258,7 +258,7 @@ openshift_cluster_content:
   #     - jenkins-ephemeral
   #     - ci-cd-deployments
   - name: jenkins-persistent
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/jenkins/jenkins-persistent-template.yml"
+    template: "{{ openshift_templates_raw }}/v1.0/jenkins/jenkins-persistent-template.yml"
     params_from_vars: "{{ jenkins.deploy }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -267,7 +267,7 @@ openshift_cluster_content:
       - jenkins-persistent
       - ci-cd-deployments
   - name: hoverfly
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.4/hoverfly/.openshift/templates/hoverfly-deployment-template.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.4/hoverfly/.openshift/templates/hoverfly-deployment-template.yml"
     params_from_vars: "{{ hoverfly.deploy }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:

--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -4,6 +4,7 @@ ansible_connection: local
 jenkins_name: jenkins
 sonarqube_name: sonarqube
 hoverfly_name: hoverfly
+nexus_password: "admin123"
 
 jenkins:
   build:
@@ -13,12 +14,28 @@ jenkins:
     BUILDER_IMAGE_STREAM_NAME: jenkins-2-rhel7
     BUILDER_IMAGE_STREAM_TAG_NAME: v3.11
     IMAGE_STREAM_NAMESPACE: "{{ ci_cd_namespace }}"
+    SECRET_NAME: "jenkins-git-password"
+    USERNAME: gitlab-sa
+    PASSWORD: "some-secret-password"
+    SOURCE_REPOSITORY_SECRET: "jenkins-git-password"
   deploy:
     NAMESPACE: "{{ ci_cd_namespace }}"
     JENKINS_IMAGE_STREAM_TAG: "{{ jenkins_name }}:latest"
-    MEMORY_LIMIT: 2Gi
+    MEMORY_LIMIT: 8Gi
     JENKINS_OPTS: "--sessionTimeout=720"
-    VOLUME_CAPACITY: 2Gi
+    VOLUME_CAPACITY: 20Gi
+    MEMORY_REQUEST: 2Gi
+    JVM_ARCH: x86_64
+
+nexus:
+  secret:
+    SECRET_NAME: "nexus-password"
+    USERNAME: admin
+    PASSWORD: "{{ nexus_password }}"
+  deploy:
+    VOLUME_CAPACITY: 10Gi
+    MEMORY_LIMIT: 2Gi
+    CONTAINER_IMAGE: sonatype/nexus3:3.15.2
 
 sonarqube:
   build:
@@ -82,6 +99,24 @@ openshift_cluster_content:
     tags:
       - sonarqube
       - sonarqube-build
+
+- object: ci-cd-secrets
+  content:
+  - name: nexus-secret
+    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/master/secrets/secret-user-pass-plaintext.yml"
+    params_from_vars: "{{ nexus.secret }}"
+    namespace: "{{ ci_cd_namespace }}"
+    tags:
+    - jenkins
+    - secret
+  - name: jenkins-secret
+    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/master/secrets/secret-user-pass-plaintext.yml"
+    params_from_vars: "{{ jenkins.build }}"
+    namespace: "{{ ci_cd_namespace }}"
+    tags:
+    - jenkins
+    - secret
+
 - object: jenkins-slave-nodes
   content:
   - name: jenkins-slave-mvn
@@ -176,6 +211,7 @@ openshift_cluster_content:
       - sonarqube
       - sonarqube-postgresql
       - sonarqube-postgresql-deploy
+      - ci-cd-deployments
   - name: sonarqube
     template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.6/sonarqube/.openshift/templates/sonarqube-deployment-template.yml"
     params_from_vars: "{{ sonarqube.deploy }}"
@@ -183,23 +219,22 @@ openshift_cluster_content:
     tags:
       - sonarqube
       - sonarqube-deploy
+      - ci-cd-deployments
   - name: nexus
     template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/nexus/nexus-deployment-template.yml"
-    params_from_vars:
-      VOLUME_CAPACITY: 10Gi
-      MEMORY_LIMIT: 2Gi
-      CONTAINER_IMAGE: sonatype/nexus3:3.15.2
+    params_from_vars: "{{ nexus.deploy }}"
     namespace: "{{ ci_cd_namespace }}"
     post_steps:
     - role: infra-ansible/roles/config-nexus
       vars:
         nexus_namespace: "{{ ci_cd_namespace }}"
         nexus_user: "admin"
-        nexus_password: "admin123"
+        nexus_password: "{{ nexus_password }}"
         nexus_api_base_path: /service/rest/v1
     tags:
       - nexus
       - nexus-deploy
+      - ci-cd-deployments
   - name: jenkins-ephemeral
     template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/jenkins/jenkins-ephemeral-template.yml"
     params_from_vars: "{{ jenkins.deploy }}"
@@ -207,6 +242,17 @@ openshift_cluster_content:
     tags:
       - jenkins
       - jenkins-deploy
+      - jenkins-persistent
+      - ci-cd-deployments
+  - name: jenkins-persistent
+    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/jenkins/jenkins-persistent-template.yml"
+    params_from_vars: "{{ jenkins.deploy }}"
+    namespace: "{{ ci_cd_namespace }}"
+    tags:
+      - jenkins
+      - jenkins-deploy
+      - jenkins-persistent
+      - ci-cd-deployments
   - name: hoverfly
     template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.4/hoverfly/.openshift/templates/hoverfly-deployment-template.yml"
     params_from_vars: "{{ hoverfly.deploy }}"
@@ -214,3 +260,4 @@ openshift_cluster_content:
     tags:
       - hoverfly
       - hoverfly-deploy
+      - ci-cd-deployments

--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -86,7 +86,7 @@ openshift_cluster_content:
 - object: ci-cd-builds
   content:
   - name: jenkins-s2i
-    template: "{{ openshift_templates_raw }}/v1.0/jenkins-s2i-build/jenkins-s2i-build-template.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/jenkins-s2i-build/jenkins-s2i-build-template.yml"
     params_from_vars: "{{ jenkins.build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -120,7 +120,7 @@ openshift_cluster_content:
     - sonarqube-build
     - ci-cd-builds
   - name: pact-broker
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.2/pact-broker/pact-broker-build.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/pact-broker/pact-broker-build.yml"
     params_from_vars: "{{ pact_broker }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -132,7 +132,7 @@ openshift_cluster_content:
 - object: ci-cd-secrets
   content:
   - name: nexus-secret
-    template: "{{ openshift_templates_raw }}/v1.2/secrets/secret-user-pass-plaintext.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/secrets/secret-user-pass-plaintext.yml"
     params_from_vars: "{{ nexus.secret }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -140,7 +140,7 @@ openshift_cluster_content:
     - secret
     - ci-cd-secrets
   - name: jenkins-secret
-    template: "{{ openshift_templates_raw }}/v1.2/secrets/secret-user-pass-plaintext.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/secrets/secret-user-pass-plaintext.yml"
     params_from_vars: "{{ jenkins.build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -256,7 +256,7 @@ openshift_cluster_content:
       - sonarqube-deploy
       - ci-cd-deployments
   - name: nexus
-    template: "{{ openshift_templates_raw }}/v1.0/nexus/nexus-deployment-template.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/nexus/nexus-deployment-template.yml"
     params_from_vars: "{{ nexus.deploy }}"
     namespace: "{{ ci_cd_namespace }}"
     post_steps:
@@ -272,7 +272,7 @@ openshift_cluster_content:
       - ci-cd-deployments
   #  Want to use Ephemeral Jenkins? Just swap out these two lines
   # - name: jenkins-ephemeral
-  #   template: "{{ openshift_templates_raw }}/v1.0/jenkins/jenkins-ephemeral-template.yml"
+  #   template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/jenkins/jenkins-ephemeral-template.yml"
   #   params_from_vars: "{{ jenkins.deploy }}"
   #   namespace: "{{ ci_cd_namespace }}"
   #   tags:
@@ -281,7 +281,7 @@ openshift_cluster_content:
   #     - jenkins-ephemeral
   #     - ci-cd-deployments
   - name: jenkins-persistent
-    template: "{{ openshift_templates_raw }}/v1.0/jenkins/jenkins-persistent-template.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/jenkins/jenkins-persistent-template.yml"
     params_from_vars: "{{ jenkins.deploy }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -290,7 +290,7 @@ openshift_cluster_content:
       - jenkins-persistent
       - ci-cd-deployments
   - name: zalenium
-    template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.9/zalenium/.openshift/templates/zalenium-deployment.yml"
+    template: "{{ cop_quickstarts_raw }}/v1.9/zalenium/.openshift/templates/zalenium-deployment.yml"
     params_from_vars: "{{ zalenium }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -306,7 +306,7 @@ openshift_cluster_content:
       - hoverfly-deploy
       - ci-cd-deployments
   - name: pact-broker
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.2/pact-broker/pact-broker-deploy.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/pact-broker/pact-broker-deploy.yml"
     params_from_vars: "{{ pact_broker }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:

--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -67,6 +67,7 @@ hoverfly:
 openshift_cluster_content:
 - galaxy_requirements:
   - pre_post_requirements.yml # Uses openshift-label role from casl-ansible
+# CI/CD builds are customisations to base software to enhance their functionality or make them OCP ready 
 - object: ci-cd-builds
   content:
   - name: jenkins-s2i
@@ -76,6 +77,7 @@ openshift_cluster_content:
     tags:
     - jenkins
     - jenkins-build
+    - ci-cd-builds
   - name: tool-box
     template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
     params_from_vars:
@@ -85,21 +87,25 @@ openshift_cluster_content:
       SOURCE_CONTEXT_DIR: tool-box
     namespace: "{{ ci_cd_namespace }}"
     tags:
-      - tool-box
+    - tool-box
+    - ci-cd-builds
   - name: hoverfly
     template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
     params_from_vars: "{{ hoverfly.build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
-      - hoverfly
+    - hoverfly
+    - ci-cd-builds
   - name: sonarqube
     template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.4/build-docker-generic/.openshift/templates/docker-build-template.yml"
     params_from_vars: "{{ sonarqube.build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
-      - sonarqube
-      - sonarqube-build
+    - sonarqube
+    - sonarqube-build
+    - ci-cd-builds
 
+# Secrets stored in OCP land and sync'd to Jenkins for consumption
 - object: ci-cd-secrets
   content:
   - name: nexus-secret
@@ -109,6 +115,7 @@ openshift_cluster_content:
     tags:
     - jenkins
     - secret
+    - ci-cd-secrets
   - name: jenkins-secret
     template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/master/secrets/secret-user-pass-plaintext.yml"
     params_from_vars: "{{ jenkins.build }}"
@@ -116,7 +123,9 @@ openshift_cluster_content:
     tags:
     - jenkins
     - secret
+    - ci-cd-secrets
 
+# Jenkins slave agents to give him some superpowers in OCP land
 - object: jenkins-slave-nodes
   content:
   - name: jenkins-slave-mvn
@@ -182,6 +191,9 @@ openshift_cluster_content:
     tags:
       - jenkins-slaves
       - python-slave
+
+# CI/CD Deployments is the OpenShift Deployment Configs and all
+# supporting tooling, pre and post hooks needed to setup and configure a comprehensive tool chain
 - object: ci-cd-deployments
   content: ## SONARQUBE DB DEPLOYMENT MUST COME BEFORE SONARQUBE DEPLOYMENT OR THE JDBC SECRETS WILL NOT BE CREATED PROPERLY
   - name: sonardb
@@ -235,15 +247,16 @@ openshift_cluster_content:
       - nexus
       - nexus-deploy
       - ci-cd-deployments
-  - name: jenkins-ephemeral
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/jenkins/jenkins-ephemeral-template.yml"
-    params_from_vars: "{{ jenkins.deploy }}"
-    namespace: "{{ ci_cd_namespace }}"
-    tags:
-      - jenkins
-      - jenkins-deploy
-      - jenkins-persistent
-      - ci-cd-deployments
+  #  Want to use Ephemeral Jenkins? Just swap out these two lines
+  # - name: jenkins-ephemeral
+  #   template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/jenkins/jenkins-ephemeral-template.yml"
+  #   params_from_vars: "{{ jenkins.deploy }}"
+  #   namespace: "{{ ci_cd_namespace }}"
+  #   tags:
+  #     - jenkins
+  #     - jenkins-deploy
+  #     - jenkins-ephemeral
+  #     - ci-cd-deployments
   - name: jenkins-persistent
     template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/jenkins/jenkins-persistent-template.yml"
     params_from_vars: "{{ jenkins.deploy }}"

--- a/inventory/host_vars/ci-for-labs-ci-cd.yml
+++ b/inventory/host_vars/ci-for-labs-ci-cd.yml
@@ -13,7 +13,7 @@ openshift_cluster_content:
 - object: ci-for-labs-ci-cd
   content:
   - name: pipeline
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.1/jenkins-pipelines/jenkins-pipeline-with-ocp-triggers-template.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/jenkins-pipelines/jenkins-pipeline-with-ocp-triggers-template.yml"
     params_from_vars: "{{ build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:

--- a/inventory/host_vars/projects-and-policies.yml
+++ b/inventory/host_vars/projects-and-policies.yml
@@ -46,7 +46,15 @@ openshift_cluster_content:
   content:
   - name: "{{ ci_cd_namespace }}-acl"
     template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
-    params_from_vars: "{{ role_binding_group }}"
+    params_from_vars: "{{ edit_role_binding_group }}"
+    namespace: "{{ ci_cd_namespace }}"
+    tags:
+    - "{{ ci_cd_namespace }}"
+    - rolebinding-group
+    - "rolebinding-group-{{ ci_cd_namespace }}"
+  - name: "{{ ci_cd_namespace }}-acl"
+    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
+    params_from_vars: "{{ admin_role_binding_group }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
     - "{{ ci_cd_namespace }}"
@@ -54,7 +62,15 @@ openshift_cluster_content:
     - "rolebinding-group-{{ ci_cd_namespace }}"
   - name: "{{ dev_namespace }}-acl"
     template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
-    params_from_vars: "{{ role_binding_group }}"
+    params_from_vars: "{{ edit_role_binding_group }}"
+    namespace: "{{ dev_namespace }}"
+    tags:
+    - "{{ dev_namespace }}"
+    - rolebinding-group
+    - "rolebinding-group-{{ dev_namespace }}"
+  - name: "{{ dev_namespace }}-acl"
+    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
+    params_from_vars: "{{ admin_role_binding_group }}"
     namespace: "{{ dev_namespace }}"
     tags:
     - "{{ dev_namespace }}"
@@ -62,7 +78,15 @@ openshift_cluster_content:
     - "rolebinding-group-{{ dev_namespace }}"
   - name: "{{ test_namespace }}-acl"
     template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
-    params_from_vars: "{{ role_binding_group }}"
+    params_from_vars: "{{ edit_role_binding_group }}"
+    namespace: "{{ test_namespace }}"
+    tags:
+    - "{{ test_namespace }}"
+    - rolebinding-group
+    - "rolebinding-group-{{ test_namespace }}"
+  - name: "{{ test_namespace }}-acl"
+    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
+    params_from_vars: "{{ admin_role_binding_group }}"
     namespace: "{{ test_namespace }}"
     tags:
     - "{{ test_namespace }}"

--- a/inventory/host_vars/projects-and-policies.yml
+++ b/inventory/host_vars/projects-and-policies.yml
@@ -17,7 +17,7 @@ openshift_cluster_content:
 - object: projectrequest
   content:
   - name: "{{ ci_cd_namespace }}"
-    template: "{{ openshift_templates_raw }}/v1.2/project-requests/create-project.yml"
+    template: "{{ openshift_templates_raw }}/v1.3/project-requests/create-project.yml"
     params_from_vars: "{{ ci_cd }}"
     action: create
     tags:
@@ -25,7 +25,7 @@ openshift_cluster_content:
     - projects
     - "projects-{{ ci_cd_namespace }}"
   - name: "{{ dev_namespace }}"    
-    template: "{{ openshift_templates_raw }}/v1.2/project-requests/create-project.yml"
+    template: "{{ openshift_templates_raw }}/v1.3/project-requests/create-project.yml"
     params_from_vars: "{{ dev }}"
     action: create
     tags:
@@ -33,7 +33,7 @@ openshift_cluster_content:
     - projects
     - "projects-{{ dev_namespace }}"
   - name: "{{ test_namespace }}"
-    template: "{{ openshift_templates_raw }}/v1.2/project-requests/create-project.yml"
+    template: "{{ openshift_templates_raw }}/v1.3/project-requests/create-project.yml"
     params_from_vars: "{{ test }}"
     action: create
     tags:

--- a/inventory/host_vars/projects-and-policies.yml
+++ b/inventory/host_vars/projects-and-policies.yml
@@ -8,15 +8,15 @@ openshift_cluster_content:
 - object: projectrequest
   content:
   - name: "{{ ci_cd_namespace }}"
-    template: "https://raw.githubusercontent.com/redhat-cop/cluster-lifecycle/v3.9.0/files/projectrequest/template.yml"
+    template: "{{ openshift_templates_raw }}/v1.2/project-requests/create-project.yml"
     params_from_vars: "{{ ci_cd }}"
     action: create
     tags:
     - "{{ ci_cd_namespace }}"
     - projects
     - "projects-{{ ci_cd_namespace }}"
-  - name: "{{ dev_namespace }}"
-    template: "https://raw.githubusercontent.com/redhat-cop/cluster-lifecycle/v3.9.0/files/projectrequest/template.yml"
+  - name: "{{ dev_namespace }}"    
+    template: "{{ openshift_templates_raw }}/v1.2/project-requests/create-project.yml"
     params_from_vars: "{{ dev }}"
     action: create
     tags:
@@ -24,7 +24,7 @@ openshift_cluster_content:
     - projects
     - "projects-{{ dev_namespace }}"
   - name: "{{ test_namespace }}"
-    template: "https://raw.githubusercontent.com/redhat-cop/cluster-lifecycle/v3.9.0/files/projectrequest/template.yml"
+    template: "{{ openshift_templates_raw }}/v1.2/project-requests/create-project.yml"
     params_from_vars: "{{ test }}"
     action: create
     tags:
@@ -34,7 +34,7 @@ openshift_cluster_content:
 - object: group-role-binding
   content:
   - name: "{{ ci_cd_namespace }}-acl"
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/role-bindings/group-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
     params_from_vars: "{{ role_binding_group }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -42,7 +42,7 @@ openshift_cluster_content:
     - rolebinding-group
     - "rolebinding-group-{{ ci_cd_namespace }}"
   - name: "{{ dev_namespace }}-acl"
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/role-bindings/group-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
     params_from_vars: "{{ role_binding_group }}"
     namespace: "{{ dev_namespace }}"
     tags:
@@ -50,7 +50,7 @@ openshift_cluster_content:
     - rolebinding-group
     - "rolebinding-group-{{ dev_namespace }}"
   - name: "{{ test_namespace }}-acl"
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/role-bindings/group-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
     params_from_vars: "{{ role_binding_group }}"
     namespace: "{{ test_namespace }}"
     tags:
@@ -58,7 +58,7 @@ openshift_cluster_content:
     - rolebinding-group
     - "rolebinding-group-{{ test_namespace }}"
   - name: "jenkins-{{ dev_namespace }}-role-binding"
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/role-bindings/jenkins-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/jenkins-rolebinding-template.yml"
     params_from_vars: "{{ jenkins }}"
     namespace: "{{ dev_namespace }}"
     tags:
@@ -66,7 +66,7 @@ openshift_cluster_content:
     - rolebinding-jenkins
     - "rolebinding-jenkins-{{ dev_namespace }}"
   - name: "jenkins-{{ test_namespace }}-role-binding"
-    template: "https://raw.githubusercontent.com/rht-labs/openshift-templates/v1.0/role-bindings/jenkins-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/jenkins-rolebinding-template.yml"
     params_from_vars: "{{ jenkins }}"
     namespace: "{{ test_namespace }}"
     tags:

--- a/inventory/host_vars/projects-and-policies.yml
+++ b/inventory/host_vars/projects-and-policies.yml
@@ -1,9 +1,18 @@
 ---
 ansible_connection: local
 
-jenkins:
-  JENKINS_NAMESPACE: "{{ ci_cd_namespace }}"
 
+jenkins:
+  ROLE: admin
+  PIPELINES_NAMESPACE: "{{ ci_cd_namespace }}"
+  DEPLOYER_USER: jenkins
+
+image_puller:
+  ROLE: "system:image-puller"
+  PIPELINES_NAMESPACE: "{{ ci_cd_namespace }}"
+  DEPLOYER_USER: default
+
+# Create new projects with a given short name and display name
 openshift_cluster_content:
 - object: projectrequest
   content:
@@ -31,6 +40,8 @@ openshift_cluster_content:
     - "{{ test_namespace }}"
     - projects
     - "projects-{{ test_namespace }}"
+
+#  Bind user groups to roles for each of the new project eg giving ocp-devs edit access in the labs-ci-cd project
 - object: group-role-binding
   content:
   - name: "{{ ci_cd_namespace }}-acl"
@@ -57,8 +68,13 @@ openshift_cluster_content:
     - "{{ test_namespace }}"
     - rolebinding-group
     - "rolebinding-group-{{ test_namespace }}"
+
+
+# Bindings to allow Jenkins operate outside of the project he's created in
+- object: service-user-role-bind
+  content:
   - name: "jenkins-{{ dev_namespace }}-role-binding"
-    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/jenkins-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/v1.2/role-bindings/generic-service-user-bind.yml"
     params_from_vars: "{{ jenkins }}"
     namespace: "{{ dev_namespace }}"
     tags:
@@ -66,10 +82,30 @@ openshift_cluster_content:
     - rolebinding-jenkins
     - "rolebinding-jenkins-{{ dev_namespace }}"
   - name: "jenkins-{{ test_namespace }}-role-binding"
-    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/jenkins-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/v1.2/role-bindings/generic-service-user-bind.yml"
     params_from_vars: "{{ jenkins }}"
     namespace: "{{ test_namespace }}"
     tags:
     - "{{ test_namespace }}"
     - rolebinding-jenkins
     - "rolebinding-jenkins-{{ test_namespace }}"
+
+# Add image puller role to be able to get images stored in other namespace
+- object: image-puller-role-binding
+  content:
+  - name: "image-puller-{{ dev_namespace }}-role-binding"
+    template: "{{ openshift_templates_raw }}/v1.2/role-bindings/generic-service-user-bind.yml"
+    params_from_vars: "{{ image_puller }}"
+    namespace: "{{ dev_namespace }}"
+    tags:
+    - "{{ dev_namespace }}"
+    - rolebinding-image-puller
+    - "rolebinding-image-puller-{{ dev_namespace }}"
+  - name: "image-puller-{{ test_namespace }}-role-binding"
+    template: "{{ openshift_templates_raw }}/v1.2/role-bindings/generic-service-user-bind.yml"
+    params_from_vars: "{{ image_puller }}"
+    namespace: "{{ test_namespace }}"
+    tags:
+    - "{{ test_namespace }}"
+    - rolebinding-image-puller
+    - "rolebinding-image-puller-{{ test_namespace }}"

--- a/inventory/host_vars/projects-and-policies.yml
+++ b/inventory/host_vars/projects-and-policies.yml
@@ -17,7 +17,7 @@ openshift_cluster_content:
 - object: projectrequest
   content:
   - name: "{{ ci_cd_namespace }}"
-    template: "{{ openshift_templates_raw }}/v1.3/project-requests/create-project.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/project-requests/create-project.yml"
     params_from_vars: "{{ ci_cd }}"
     action: create
     tags:
@@ -25,7 +25,7 @@ openshift_cluster_content:
     - projects
     - "projects-{{ ci_cd_namespace }}"
   - name: "{{ dev_namespace }}"    
-    template: "{{ openshift_templates_raw }}/v1.3/project-requests/create-project.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/project-requests/create-project.yml"
     params_from_vars: "{{ dev }}"
     action: create
     tags:
@@ -33,7 +33,7 @@ openshift_cluster_content:
     - projects
     - "projects-{{ dev_namespace }}"
   - name: "{{ test_namespace }}"
-    template: "{{ openshift_templates_raw }}/v1.3/project-requests/create-project.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/project-requests/create-project.yml"
     params_from_vars: "{{ test }}"
     action: create
     tags:
@@ -45,7 +45,7 @@ openshift_cluster_content:
 - object: group-role-binding
   content:
   - name: "{{ ci_cd_namespace }}-acl"
-    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/role-bindings/group-rolebinding-template.yml"
     params_from_vars: "{{ edit_role_binding_group }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -53,7 +53,7 @@ openshift_cluster_content:
     - rolebinding-group
     - "rolebinding-group-{{ ci_cd_namespace }}"
   - name: "{{ ci_cd_namespace }}-acl"
-    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/role-bindings/group-rolebinding-template.yml"
     params_from_vars: "{{ admin_role_binding_group }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:
@@ -61,7 +61,7 @@ openshift_cluster_content:
     - rolebinding-group
     - "rolebinding-group-{{ ci_cd_namespace }}"
   - name: "{{ dev_namespace }}-acl"
-    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/role-bindings/group-rolebinding-template.yml"
     params_from_vars: "{{ edit_role_binding_group }}"
     namespace: "{{ dev_namespace }}"
     tags:
@@ -69,7 +69,7 @@ openshift_cluster_content:
     - rolebinding-group
     - "rolebinding-group-{{ dev_namespace }}"
   - name: "{{ dev_namespace }}-acl"
-    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/role-bindings/group-rolebinding-template.yml"
     params_from_vars: "{{ admin_role_binding_group }}"
     namespace: "{{ dev_namespace }}"
     tags:
@@ -77,7 +77,7 @@ openshift_cluster_content:
     - rolebinding-group
     - "rolebinding-group-{{ dev_namespace }}"
   - name: "{{ test_namespace }}-acl"
-    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/role-bindings/group-rolebinding-template.yml"
     params_from_vars: "{{ edit_role_binding_group }}"
     namespace: "{{ test_namespace }}"
     tags:
@@ -85,7 +85,7 @@ openshift_cluster_content:
     - rolebinding-group
     - "rolebinding-group-{{ test_namespace }}"
   - name: "{{ test_namespace }}-acl"
-    template: "{{ openshift_templates_raw }}/v1.0/role-bindings/group-rolebinding-template.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/role-bindings/group-rolebinding-template.yml"
     params_from_vars: "{{ admin_role_binding_group }}"
     namespace: "{{ test_namespace }}"
     tags:
@@ -98,7 +98,7 @@ openshift_cluster_content:
 - object: service-user-role-bind
   content:
   - name: "jenkins-{{ dev_namespace }}-role-binding"
-    template: "{{ openshift_templates_raw }}/v1.2/role-bindings/generic-service-user-bind.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/role-bindings/generic-service-user-bind.yml"
     params_from_vars: "{{ jenkins }}"
     namespace: "{{ dev_namespace }}"
     tags:
@@ -106,7 +106,7 @@ openshift_cluster_content:
     - rolebinding-jenkins
     - "rolebinding-jenkins-{{ dev_namespace }}"
   - name: "jenkins-{{ test_namespace }}-role-binding"
-    template: "{{ openshift_templates_raw }}/v1.2/role-bindings/generic-service-user-bind.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/role-bindings/generic-service-user-bind.yml"
     params_from_vars: "{{ jenkins }}"
     namespace: "{{ test_namespace }}"
     tags:
@@ -118,7 +118,7 @@ openshift_cluster_content:
 - object: image-puller-role-binding
   content:
   - name: "image-puller-{{ dev_namespace }}-role-binding"
-    template: "{{ openshift_templates_raw }}/v1.2/role-bindings/generic-service-user-bind.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/role-bindings/generic-service-user-bind.yml"
     params_from_vars: "{{ image_puller }}"
     namespace: "{{ dev_namespace }}"
     tags:
@@ -126,7 +126,7 @@ openshift_cluster_content:
     - rolebinding-image-puller
     - "rolebinding-image-puller-{{ dev_namespace }}"
   - name: "image-puller-{{ test_namespace }}-role-binding"
-    template: "{{ openshift_templates_raw }}/v1.2/role-bindings/generic-service-user-bind.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/role-bindings/generic-service-user-bind.yml"
     params_from_vars: "{{ image_puller }}"
     namespace: "{{ test_namespace }}"
     tags:


### PR DESCRIPTION
*Ready for Review / Merge*

Some changes from using labs-ci-cd with the past few customers. Mostly cosmetic with a few things we've been using in EMEA added in.

Key highlights:
* Variables for the repo address to make them easier to overwrite and customise
* Beginnings of consolidating the TONS. Should make it easier to switch when openshift-templates flies off to it's new home
* Add secrets for gitlab and nexus to jenkins sync
* Annotations of the sections of the `ci-cd-tooling.yml`
* Add role binding for admin
* Add role binding for jenkins and image puller
* Jenkins Persistent

blocked from merge until https://github.com/rht-labs/openshift-templates/pull/17