### PR TITLE
Update slave versions and fix to CoP land repos

### DIFF
--- a/params/jenkins-slaves/ansible
+++ b/params/jenkins-slaves/ansible
@@ -3,3 +3,4 @@ SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-ansible
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-ansible
 SOURCE_REPOSITORY_REF=v1.9
+SLAVE_IMAGE_TAG=latest

--- a/params/jenkins-slaves/ansible
+++ b/params/jenkins-slaves/ansible
@@ -2,5 +2,4 @@ SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/containers-quickstarts.git
 SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-ansible
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-ansible
-SOURCE_REPOSITORY_REF=v1.3
-DOCKERFILE_PATH=Dockerfile
+SOURCE_REPOSITORY_REF=v1.9

--- a/params/jenkins-slaves/arachni
+++ b/params/jenkins-slaves/arachni
@@ -3,3 +3,4 @@ SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-arachni
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-arachni
 SOURCE_REPOSITORY_REF=v1.9
+SLAVE_IMAGE_TAG=latest

--- a/params/jenkins-slaves/arachni
+++ b/params/jenkins-slaves/arachni
@@ -2,4 +2,4 @@ SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/containers-quickstarts.git
 SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-arachni
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-arachni
-SOURCE_REPOSITORY_REF=v1.3
+SOURCE_REPOSITORY_REF=v1.9

--- a/params/jenkins-slaves/golang
+++ b/params/jenkins-slaves/golang
@@ -2,4 +2,4 @@ SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/containers-quickstarts.git
 SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-golang
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-golang
-SOURCE_REPOSITORY_REF=v1.3
+SOURCE_REPOSITORY_REF=v1.9

--- a/params/jenkins-slaves/golang
+++ b/params/jenkins-slaves/golang
@@ -3,3 +3,4 @@ SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-golang
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-golang
 SOURCE_REPOSITORY_REF=v1.9
+SLAVE_IMAGE_TAG=latest

--- a/params/jenkins-slaves/gradle
+++ b/params/jenkins-slaves/gradle
@@ -2,4 +2,4 @@ SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/containers-quickstarts.git
 SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-gradle
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-gradle
-SOURCE_REPOSITORY_REF=v1.3
+SOURCE_REPOSITORY_REF=v1.9

--- a/params/jenkins-slaves/gradle
+++ b/params/jenkins-slaves/gradle
@@ -3,3 +3,4 @@ SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-gradle
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-gradle
 SOURCE_REPOSITORY_REF=v1.9
+SLAVE_IMAGE_TAG=latest

--- a/params/jenkins-slaves/mongodb
+++ b/params/jenkins-slaves/mongodb
@@ -2,4 +2,4 @@ SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/containers-quickstarts.git
 SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-mongodb
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-mongodb
-SOURCE_REPOSITORY_REF=v1.3
+SOURCE_REPOSITORY_REF=v1.9

--- a/params/jenkins-slaves/mongodb
+++ b/params/jenkins-slaves/mongodb
@@ -3,3 +3,4 @@ SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-mongodb
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-mongodb
 SOURCE_REPOSITORY_REF=v1.9
+SLAVE_IMAGE_TAG=latest

--- a/params/jenkins-slaves/mvn
+++ b/params/jenkins-slaves/mvn
@@ -2,5 +2,5 @@ SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/containers-quickstarts.git
 SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-mvn
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-agent-maven-35-rhel7:latest
 NAME=jenkins-slave-mvn
-SOURCE_REPOSITORY_REF=v1.8
+SOURCE_REPOSITORY_REF=v1.9
 DOCKERFILE_PATH=Dockerfile

--- a/params/jenkins-slaves/mvn
+++ b/params/jenkins-slaves/mvn
@@ -4,3 +4,4 @@ BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-agent-maven-35-
 NAME=jenkins-slave-mvn
 SOURCE_REPOSITORY_REF=v1.9
 DOCKERFILE_PATH=Dockerfile
+SLAVE_IMAGE_TAG=latest

--- a/params/jenkins-slaves/npm
+++ b/params/jenkins-slaves/npm
@@ -4,3 +4,4 @@ BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel
 NAME=jenkins-slave-npm
 SOURCE_REPOSITORY_REF=v1.9
 DOCKERFILE_PATH=Dockerfile.rhel7
+SLAVE_IMAGE_TAG=latest

--- a/params/jenkins-slaves/python
+++ b/params/jenkins-slaves/python
@@ -3,3 +3,4 @@ SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-python
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-python
 SOURCE_REPOSITORY_REF=v1.9
+SLAVE_IMAGE_TAG=latest

--- a/params/jenkins-slaves/python
+++ b/params/jenkins-slaves/python
@@ -2,4 +2,4 @@ SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/containers-quickstarts.git
 SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-python
 BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 NAME=jenkins-slave-python
-SOURCE_REPOSITORY_REF=v1.3
+SOURCE_REPOSITORY_REF=v1.9

--- a/params/jenkins-slaves/zap
+++ b/params/jenkins-slaves/zap
@@ -4,3 +4,4 @@ BUILDER_IMAGE_NAME=centos:centos7
 NAME=jenkins-slave-zap
 SOURCE_REPOSITORY_REF=v1.9
 DOCKERFILE_PATH=Dockerfile
+SLAVE_IMAGE_TAG=latest

--- a/params/jenkins-slaves/zap
+++ b/params/jenkins-slaves/zap
@@ -1,5 +1,6 @@
-SOURCE_REPOSITORY_URL=https://github.com/rht-labs/owasp-zap-openshift.git
+SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/containers-quickstarts.git
+SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-python
 BUILDER_IMAGE_NAME=centos:centos7
 NAME=jenkins-slave-zap
-SOURCE_REPOSITORY_REF=master
+SOURCE_REPOSITORY_REF=v1.9
 DOCKERFILE_PATH=Dockerfile

--- a/params/jenkins-slaves/zap
+++ b/params/jenkins-slaves/zap
@@ -1,5 +1,5 @@
 SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/containers-quickstarts.git
-SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-python
+SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-zap
 BUILDER_IMAGE_NAME=centos:centos7
 NAME=jenkins-slave-zap
 SOURCE_REPOSITORY_REF=v1.9


### PR DESCRIPTION
Updated the slaves to the latest cut of container-quickstarts. I would like to move the config more towards `params_from_vars` too as there is soo much repetition in the `params` dir