### PR TITLE
Fixed openshift-templates path

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -3,7 +3,7 @@ dev_namespace: labs-dev
 test_namespace: labs-test
 
 # When the ocp_templates gets moved to cop land we can merge the two raws below
-openshift_templates_raw: "https://raw.githubusercontent.com/rht-labs/openshift-templates"
+openshift_templates_raw: "https://raw.githubusercontent.com/redhat-cop/openshift-templates"
 openshift_templates_raw_version_tag: "v1.3"
 cop_quickstarts: "https://github.com/redhat-cop/containers-quickstarts.git"
 cop_quickstarts_raw: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts"


### PR DESCRIPTION
Openshift-templates repo looks to have moved to the redhat-cop github, I've updated the path.