### PR TITLE
Fix ci pipeline file link

### DIFF
--- a/inventory/host_vars/ci-for-labs-ci-cd.yml
+++ b/inventory/host_vars/ci-for-labs-ci-cd.yml
@@ -13,7 +13,7 @@ openshift_cluster_content:
 - object: ci-for-labs-ci-cd
   content:
   - name: pipeline
-    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/jenkins-pipelines/jenkins-pipeline-with-ocp-triggers-template.yml"
+    template: "{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/jenkins-pipelines/jenkins-pipeline-template-with-ocp-triggers.yml"
     params_from_vars: "{{ build }}"
     namespace: "{{ ci_cd_namespace }}"
     tags:


### PR DESCRIPTION
@oybed apparently this was broken on master. our automation for ci-for-ci setup must be hitting an old tag, which makes me very happy actually. tags keeping us safe! :1st_place_medal: :smile: but we'll need to test and update