### PR TITLE
Maven Jenkins Slave Using Incorrect Base Image

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -6,7 +6,7 @@ openshift_templates_raw: "https://raw.githubusercontent.com/redhat-cop/openshift
 openshift_templates_raw_version_tag: "v1.4.12"
 cop_quickstarts: "https://github.com/redhat-cop/containers-quickstarts.git"
 cop_quickstarts_raw: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts"
-cop_quickstarts_raw_version_tag: "v1.14"
+cop_quickstarts_raw_version_tag: "v1.18"
 
 ci_cd:
   NAMESPACE: "{{ ci_cd_namespace }}"

--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -63,6 +63,7 @@ jenkins_slaves:
       SOURCE_REPOSITORY_REF: "{{ cop_quickstarts_raw_version_tag }}"
       SOURCE_REPOSITORY_URL: "{{ cop_quickstarts }}"
     mvn:
+      BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-maven:4.2
       NAME: jenkins-slave-mvn
       SOURCE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-mvn
       SOURCE_REPOSITORY_REF: "{{ cop_quickstarts_raw_version_tag }}"


### PR DESCRIPTION
#### What is this PR About?

When trying to use the jenkins slave for Maven, you will currently get a failure stating  'mvn: command not found'.  This is a result of the default value being specified for the builder image.  This PR specifies the BUILDER_IMAGE_NAME in the ci-cd-tooling.yml.  It also updated to the latest version of the COP project (v1.18).

#### How should we test or review this PR?

This PR can be tested by running the Labs CI CD project against an OpenShift cluster.  Then deploying Maven project that calls a Maven command from its Jenkinsfile.

#### Is there a relevant Trello card or Github issue open for this?

None that I am aware of.

#### Who would you like to review this?

cc: @rht-labs/OpenInnovationLabs

'''''

* [ ] Have you followed the
[contributing
guidelines?](https://github.com/rht-labs/labs-ci-cd/blob/master/CONTRIBUTING.adoc)
* [ ] Have you explained what your changes do, and why they add value to
Labs CI / CD?

'''''

*Please note: we may close your PR without comment if you do not check
the boxes above and provide ALL requested information.*
